### PR TITLE
POC: user job description for skill extraction, seed cleanup, and LLM observability

### DIFF
--- a/backend/src/agents/skillExtraction.agent.ts
+++ b/backend/src/agents/skillExtraction.agent.ts
@@ -1,8 +1,12 @@
 import { llmCall } from '../infra/llm/llmCall';
 import { parseJsonSafe } from '../infra/llm/parseJson';
 import { AgentError } from './agentError';
+import { logSkillExtractionAgentPayload } from '../utils/pocLog';
 
 const AGENT_NAME = 'skillExtraction';
+
+/** User message prefix — keep in sync with `logSkillExtractionAgentPayload` wording in pocLog. */
+const USER_MESSAGE_PREFIX = 'Job description:\n';
 
 const SYSTEM_PROMPT = `You are a job skills expert.
 Read the job description below and extract exactly 5 skills that are
@@ -14,9 +18,14 @@ Rules:
 - No duplicates. No explanation. No markdown. Just the JSON array.`;
 
 export async function extractSkills(jobDescription: string): Promise<string[]> {
+  const userContent = `${USER_MESSAGE_PREFIX}${jobDescription}`;
+  logSkillExtractionAgentPayload({
+    jobDescriptionChars: jobDescription.length,
+    userMessageChars: userContent.length,
+  });
   const raw = await llmCall(AGENT_NAME, [
     { role: 'system', content: SYSTEM_PROMPT },
-    { role: 'user', content: `Job description:\n${jobDescription}` },
+    { role: 'user', content: userContent },
   ]);
 
   const parsed = await parseJsonSafe<unknown>(raw, AGENT_NAME);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,7 +3,7 @@ import app from './app';
 import { connectDB } from './config/db';
 import { logPocStartup } from './utils/pocLog';
 
-const PORT = process.env.PORT ?? 8000;
+const PORT = Number(process.env.PORT) || 8000;
 
 async function main() {
   logPocStartup();

--- a/backend/src/models/job.model.ts
+++ b/backend/src/models/job.model.ts
@@ -3,7 +3,7 @@ import { Schema, model, Document } from 'mongoose';
 export interface IJob extends Document {
   title: string;
   normalizedTitle: string;
-  /** Stored JD snippet for POC dynamic skill extraction when the client only sends jobId */
+  /** Optional; POC analyze uses the client `jobDescription` body field, not this. */
   description?: string;
   metadata?: Record<string, unknown>;
 }

--- a/backend/src/routes/analyze.routes.ts
+++ b/backend/src/routes/analyze.routes.ts
@@ -149,10 +149,13 @@ export function mergeTenSkills(jobTitle: string, core: string[], dynamic: string
   return out.slice(0, 10);
 }
 
+const MIN_JOB_DESCRIPTION_CHARS = 40;
+
 /**
  * POST /api/analyze
  *
- * POC: { jobId, cvText } — job description is loaded from the Job document.
+ * POC: { jobId, cvText, jobDescription } — user supplies the JD text for dynamic skill extraction;
+ *       jobId selects role (core skills + DB record). Stored Job.description is not used for extraction.
  * Legacy: { jobTitle, jobDescription, cvText }
  */
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
@@ -169,15 +172,20 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
 
     if (jobId && cvText) {
       job = await validateJobById(jobId);
-      descriptionForDynamic =
-        job.description?.trim() ||
-        `${job.title}: professional role requiring strong execution, collaboration, and domain-relevant technical skills.`;
+      const jd =
+        typeof jobDescription === 'string' ? jobDescription.trim() : '';
+      if (jd.length < MIN_JOB_DESCRIPTION_CHARS) {
+        throw new ValidationError(
+          `jobDescription is required (at least ${MIN_JOB_DESCRIPTION_CHARS} characters) — paste the job posting for skill extraction`
+        );
+      }
+      descriptionForDynamic = jd;
     } else if (jobTitle && jobDescription && cvText) {
       job = await validateJobTitle(jobTitle);
       descriptionForDynamic = jobDescription;
     } else {
       throw new ValidationError(
-        'Provide jobId and cvText, or jobTitle, jobDescription, and cvText'
+        'Provide jobId, cvText, and jobDescription, or jobTitle, jobDescription, and cvText'
       );
     }
 

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -4,36 +4,11 @@ import { connectDB } from '../config/db';
 import { Job } from '../models/job.model';
 
 const POC_JOBS = [
-  {
-    title: 'Software Engineer',
-    normalizedTitle: 'software-engineer',
-    description:
-      'Design and build scalable backend services. Strong experience with REST APIs, automated testing, code review, and CI/CD. Collaborate on architecture decisions and performance tuning.',
-  },
-  {
-    title: 'Data Scientist',
-    normalizedTitle: 'data-scientist',
-    description:
-      'Build and evaluate ML models, run experiments, and communicate insights. Proficiency in Python, SQL, statistics, and visualization tools. Work with stakeholders to define metrics and hypotheses.',
-  },
-  {
-    title: 'Product Manager',
-    normalizedTitle: 'product-manager',
-    description:
-      'Own roadmap and prioritization. Run discovery with users, align engineering and design, and use data to validate decisions. Experience with agile delivery and stakeholder management.',
-  },
-  {
-    title: 'DevOps Engineer',
-    normalizedTitle: 'devops-engineer',
-    description:
-      'Automate deployments and manage cloud infrastructure. Hands-on with Docker, Kubernetes, Terraform, and CI/CD pipelines. Ensure reliability, monitoring, and security best practices.',
-  },
-  {
-    title: 'Frontend Developer',
-    normalizedTitle: 'frontend-developer',
-    description:
-      'Implement responsive UIs with React and TypeScript. Focus on accessibility, performance, and collaboration with UX. Experience with modern build tooling and cross-browser testing.',
-  },
+  { title: 'Software Engineer', normalizedTitle: 'software-engineer' },
+  { title: 'Data Scientist', normalizedTitle: 'data-scientist' },
+  { title: 'Product Manager', normalizedTitle: 'product-manager' },
+  { title: 'DevOps Engineer', normalizedTitle: 'devops-engineer' },
+  { title: 'Frontend Developer', normalizedTitle: 'frontend-developer' },
 ];
 
 async function seed() {

--- a/backend/src/services/job.service.ts
+++ b/backend/src/services/job.service.ts
@@ -4,7 +4,7 @@ import { IJob } from '../models/job.model';
 import { getCoreSkills } from './dsModel';
 import { extractSkills } from '../agents/skillExtraction.agent';
 import { ValidationError, NotFoundError, DsModelError } from '../errors';
-import { logFallbackDynamicSkills } from '../utils/pocLog';
+import { logFallbackDynamicSkills, logLlmDynamicSkillsOk } from '../utils/pocLog';
 
 export async function listJobs(): Promise<IJob[]> {
   const jobs = await getPocJobsForList();
@@ -102,6 +102,7 @@ export async function extractDynamicSkills(
 }> {
   try {
     const extractedSkills = await extractSkills(jobDescription);
+    logLlmDynamicSkillsOk(jobTitle);
     return { jobTitle, extractedSkills, dynamicSource: 'llm_job_description' };
   } catch {
     const perJob = FALLBACK_DYNAMIC_BY_TITLE[jobTitle];

--- a/backend/src/services/job.service.ts
+++ b/backend/src/services/job.service.ts
@@ -4,7 +4,12 @@ import { IJob } from '../models/job.model';
 import { getCoreSkills } from './dsModel';
 import { extractSkills } from '../agents/skillExtraction.agent';
 import { ValidationError, NotFoundError, DsModelError } from '../errors';
-import { logFallbackDynamicSkills, logLlmDynamicSkillsOk } from '../utils/pocLog';
+import {
+  logFallbackDynamicSkills,
+  logJobDescriptionForExtraction,
+  logLlmDynamicSkillsOk,
+  logDebugText,
+} from '../utils/pocLog';
 
 export async function listJobs(): Promise<IJob[]> {
   const jobs = await getPocJobsForList();
@@ -101,8 +106,10 @@ export async function extractDynamicSkills(
   dynamicSource: DynamicSkillsSource;
 }> {
   try {
+    logJobDescriptionForExtraction(jobTitle, jobDescription.length);
+    logDebugText('job description (extractSkills input)', jobDescription, 400);
     const extractedSkills = await extractSkills(jobDescription);
-    logLlmDynamicSkillsOk(jobTitle);
+    logLlmDynamicSkillsOk(jobTitle, extractedSkills);
     return { jobTitle, extractedSkills, dynamicSource: 'llm_job_description' };
   } catch {
     const perJob = FALLBACK_DYNAMIC_BY_TITLE[jobTitle];

--- a/backend/src/services/scoring.service.ts
+++ b/backend/src/services/scoring.service.ts
@@ -4,7 +4,12 @@ import { parseAndSaveAnalysis } from '../dal/cvAnalysis.dal';
 import { ICvAnalysis } from '../models/cvAnalysis.model';
 import { validateSkillArray } from '../utils/validateSkills';
 import { ValidationError } from '../errors';
-import { logFallbackScoring } from '../utils/pocLog';
+import {
+  logFallbackScoring,
+  logLlmScoringOk,
+  logLlmScoringRawUnnormalized,
+  logLlmScoringUniformReplaced,
+} from '../utils/pocLog';
 
 const MIN_CV_TEXT_LENGTH = 50;
 
@@ -41,7 +46,7 @@ function normalizeLlmScoringJson(
   raw: string,
   expectedSkills: string[],
   cvText: string
-): string {
+): { json: string; uniformReplacedWithKeywords: boolean } {
   const parsed = JSON.parse(raw) as { skills?: unknown };
   if (!Array.isArray(parsed.skills)) {
     throw new Error('Invalid LLM scoring shape');
@@ -82,10 +87,16 @@ function normalizeLlmScoringJson(
   const values = aligned.map((a) => a.score);
   const allSame = values.length > 0 && values.every((n) => n === values[0]);
   if (allSame) {
-    return buildMockAgentJson(expectedSkills, cvText);
+    return {
+      json: buildMockAgentJson(expectedSkills, cvText),
+      uniformReplacedWithKeywords: true,
+    };
   }
 
-  return JSON.stringify({ skills: aligned });
+  return {
+    json: JSON.stringify({ skills: aligned }),
+    uniformReplacedWithKeywords: false,
+  };
 }
 
 export interface ScoreRequest {
@@ -118,9 +129,20 @@ export async function scoreAndPersist(req: ScoreRequest): Promise<ICvAnalysis> {
   try {
     const raw = await scoreSkills(req.cvText, validatedSkills);
     try {
-      baseInput.rawAgentOutput = normalizeLlmScoringJson(raw, validatedSkills, req.cvText);
+      const { json, uniformReplacedWithKeywords } = normalizeLlmScoringJson(
+        raw,
+        validatedSkills,
+        req.cvText
+      );
+      baseInput.rawAgentOutput = json;
+      if (uniformReplacedWithKeywords) {
+        logLlmScoringUniformReplaced(req.jobTitle);
+      } else {
+        logLlmScoringOk(req.jobTitle);
+      }
     } catch {
       baseInput.rawAgentOutput = raw;
+      logLlmScoringRawUnnormalized(req.jobTitle);
     }
     return await parseAndSaveAnalysis(baseInput);
   } catch {

--- a/backend/src/utils/pocLog.ts
+++ b/backend/src/utils/pocLog.ts
@@ -16,6 +16,8 @@ export function logPocStartup(): void {
     console.log(
       `${PREFIX} OPENAI_API_KEY not set — skill extraction and scoring use fallbacks when the API is missing or returns an error.`
     );
+  } else {
+    console.log(`${PREFIX} OPENAI_API_KEY set — LLM enabled for dynamic skills and scoring (watch per-request LLM OK / fallback lines)`);
   }
 }
 
@@ -46,4 +48,28 @@ export function logFallbackDynamicSkills(jobTitle: string, variant: 'per_job' | 
 
 export function logFallbackScoring(): void {
   console.log(`${PREFIX} Scoring fallback (keyword overlap) — OpenAI unavailable or response invalid`);
+}
+
+/** Dynamic skill extraction succeeded via OpenAI (job description → 5 skills). */
+export function logLlmDynamicSkillsOk(jobTitle: string): void {
+  console.log(`${PREFIX} LLM OK dynamic skills job=${JSON.stringify(jobTitle)}`);
+}
+
+/** Scoring used OpenAI output (aligned to the 10 skills). */
+export function logLlmScoringOk(jobTitle: string): void {
+  console.log(`${PREFIX} LLM OK scoring job=${JSON.stringify(jobTitle)}`);
+}
+
+/** Model returned the same score for every skill; replaced with keyword overlap for differentiation. */
+export function logLlmScoringUniformReplaced(jobTitle: string): void {
+  console.log(
+    `${PREFIX} LLM scoring returned uniform scores — using keyword overlap instead job=${JSON.stringify(jobTitle)}`
+  );
+}
+
+/** Scoring LLM returned text but JSON normalization failed; using raw model output as-is. */
+export function logLlmScoringRawUnnormalized(jobTitle: string): void {
+  console.log(
+    `${PREFIX} LLM scoring OK (raw JSON, normalize skipped) job=${JSON.stringify(jobTitle)}`
+  );
 }

--- a/backend/src/utils/pocLog.ts
+++ b/backend/src/utils/pocLog.ts
@@ -1,6 +1,6 @@
 /**
  * Minimal production-friendly logging for the POC.
- * Set POC_DEBUG=1 for optional text previews (CV snippets) in cv.service.
+ * Set POC_DEBUG=1 for optional text previews (CV snippets, job description input to extractSkills).
  */
 
 const PREFIX = '[CareerLens]';
@@ -50,9 +50,33 @@ export function logFallbackScoring(): void {
   console.log(`${PREFIX} Scoring fallback (keyword overlap) — OpenAI unavailable or response invalid`);
 }
 
+/** Client job description accepted for dynamic extraction (before LLM). */
+export function logJobDescriptionForExtraction(jobTitle: string, descriptionChars: number): void {
+  console.log(
+    `${PREFIX} Job description OK for dynamic skills job=${JSON.stringify(jobTitle)} descriptionChars=${descriptionChars}`
+  );
+}
+
+/**
+ * What `skillExtraction` sends to the chat API: fixed system prompt + one user message
+ * `"Job description:\\n" + <full JD text>`.
+ */
+export function logSkillExtractionAgentPayload(meta: {
+  jobDescriptionChars: number;
+  userMessageChars: number;
+}): void {
+  console.log(
+    `${PREFIX} skillExtraction → OpenAI: system=fixed rules; user="Job description:\\n"+JD (${meta.jobDescriptionChars} chars); userMessageTotalChars=${meta.userMessageChars}`
+  );
+}
+
 /** Dynamic skill extraction succeeded via OpenAI (job description → 5 skills). */
-export function logLlmDynamicSkillsOk(jobTitle: string): void {
-  console.log(`${PREFIX} LLM OK dynamic skills job=${JSON.stringify(jobTitle)}`);
+export function logLlmDynamicSkillsOk(jobTitle: string, extractedSkills?: string[]): void {
+  const skillsPart =
+    extractedSkills && extractedSkills.length > 0
+      ? ` extracted=${JSON.stringify(extractedSkills)}`
+      : '';
+  console.log(`${PREFIX} LLM OK dynamic skills job=${JSON.stringify(jobTitle)}${skillsPart}`);
 }
 
 /** Scoring used OpenAI output (aligned to the 10 skills). */

--- a/docs/POC.md
+++ b/docs/POC.md
@@ -1,6 +1,6 @@
 # CareerLens POC Current Flow
 
-Short overview: the POC is a **single linear path** in the React app. The user uploads a **PDF CV**, picks **one of five seeded jobs**, and submits. The frontend calls the Node backend (`/api/...`), which extracts text, merges **10 skills** (5 static “core” + 5 dynamic), scores them (OpenAI when available, otherwise fallbacks), and returns JSON. The **Skills Match Dashboard** reads the last result from **`sessionStorage`** (set after a successful analyze).
+Short overview: the POC is a **single linear path** in the React app. The user uploads a **PDF CV**, picks **one of five seeded jobs**, **pastes a job description** (the posting text used for dynamic skill extraction), and submits. The frontend calls the Node backend (`/api/...`), which merges **10 skills** (5 static “core” + 5 dynamic from that pasted text), scores them (OpenAI when available, otherwise fallbacks), and returns JSON. The **Skills Match Dashboard** reads the last result from **`sessionStorage`** (set after a successful analyze).
 
 ---
 
@@ -8,8 +8,9 @@ Short overview: the POC is a **single linear path** in the React app. The user u
 
 1. **Upload CV** — PDF only; `POST /api/upload` returns extracted normalized text.
 2. **Choose one of 5 jobs** — `GET /api/jobs` loads the list; dropdown uses Mongo-backed jobs (seed script inserts five titles).
-3. **Analyze** — `POST /api/analyze` with `jobId` + `cvText` from the previous step.
-4. **View results** — Navigate to `/dashboard`; UI reads `sessionStorage` key `pocAnalysisResult` and shows job title, 10 skill bars, and match score.
+3. **Paste job description** — User-provided posting text (min 40 characters); **not** taken from the `Job` document for extraction.
+4. **Analyze** — `POST /api/analyze` with `jobId` + `cvText` + `jobDescription` from the previous steps.
+5. **View results** — Navigate to `/dashboard`; UI reads `sessionStorage` key `pocAnalysisResult` and shows job title, 10 skill bars, and match score.
 
 ---
 
@@ -19,7 +20,7 @@ Short overview: the POC is a **single linear path** in the React app. The user u
 |--------|------|-------------|
 | `GET` | `/api/jobs` | List jobs for the dropdown (`id`, `title`, `skills` preview from static core map). |
 | `POST` | `/api/upload` | Multipart field **`file`** (PDF) → `{ cvText }`. |
-| `POST` | `/api/analyze` | JSON body **`{ jobId, cvText }`** → analysis JSON (see Data Contract). |
+| `POST` | `/api/analyze` | JSON body **`{ jobId, cvText, jobDescription }`** → analysis JSON (see Data Contract). |
 
 All are mounted under **`/api`** in `backend/src/app.ts` (default backend port **8000**).
 
@@ -61,8 +62,9 @@ All are mounted under **`/api`** in `backend/src/app.ts` (default backend port *
 
 ### `POST /api/analyze`
 
-- **Request (JSON):** `{ "jobId": string, "cvText": string }`  
-  (`jobId` is Mongo ObjectId string for a seeded job.)
+- **Request (JSON):** `{ "jobId": string, "cvText": string, "jobDescription": string }`  
+  - `jobId`: Mongo ObjectId string for a seeded job (selects role + core skills).  
+  - `jobDescription`: user-pasted posting text; **must be at least 40 characters** after trim. Used only for dynamic skill extraction (not read from `Job.description`).
 
 - **Response (200):**
   ```json
@@ -85,7 +87,7 @@ All are mounted under **`/api`** in `backend/src/app.ts` (default backend port *
 | Jobs list | MongoDB documents | **`GET /api/jobs`** returns exactly the five canonical POC titles (in fixed order); extra DB rows are ignored. Fewer than five → **503** with a message to run **`npm run seed`**. |
 | PDF text | `pdf-parse` in `cv.service.ts` | Errors → 4xx validation (no fake text). |
 | Core 5 skills | Always from **`dsModel.ts`** static map by job title | Placeholder until a real DS/vector pipeline exists (see comments in `job.service.ts`). |
-| Dynamic 5 skills | OpenAI extraction from job **description** (`skillExtraction.agent.ts`) when call succeeds | Static per-job or generic lists in `job.service.ts` if LLM fails or key missing. |
+| Dynamic 5 skills | OpenAI extraction from **request body `jobDescription`** (`skillExtraction.agent.ts`) when call succeeds | Static per-job or generic lists in `job.service.ts` if LLM fails or key missing. |
 | Per-skill scores | OpenAI scoring (`scoring.agent.ts`) when JSON parses | Keyword overlap mock in `scoring.service.ts` if API fails or invalid agent JSON. |
 | OpenAI key | `OPENAI_API_KEY` in `backend/.env` | Server boots with placeholder key in code; LLM calls fail through to fallbacks (see `openaiClient.ts`, `pocLog.ts`). |
 

--- a/frontend/BACKEND_INTEGRATION.md
+++ b/frontend/BACKEND_INTEGRATION.md
@@ -18,7 +18,7 @@ Use **[`../docs/POC.md`](../docs/POC.md)** for:
 | `src/services/api.ts` | `app.ts` mounts `/api` |
 | `fetchJobs()` | `GET /api/jobs` |
 | `uploadPdf(file)` — field name **`file`** | `POST /api/upload` |
-| `analyzeCv(jobId, cvText)` | `POST /api/analyze` |
+| `analyzeCv(jobId, cvText, jobDescription)` | `POST /api/analyze` |
 
 Optional env: `VITE_API_BASE_URL` (no trailing slash), e.g. `http://localhost:8000/api`. If unset, the app uses relative `/api` (works with the Vite proxy).
 

--- a/frontend/src/pages/UploadScreen.css
+++ b/frontend/src/pages/UploadScreen.css
@@ -49,6 +49,42 @@
   gap: 1rem;
 }
 
+.upload-section--job .job-description-label {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin-top: 0.25rem;
+}
+
+.job-select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: inherit;
+  color: #111827;
+  background: #fff;
+  cursor: pointer;
+  min-height: 3rem;
+  transition: border-color 0.2s;
+}
+
+.job-select:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.job-select:disabled {
+  background-color: #f3f4f6;
+  cursor: not-allowed;
+}
+
+.job-description-textarea--compact {
+  min-height: 140px;
+}
+
 .section-header {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/UploadScreen.tsx
+++ b/frontend/src/pages/UploadScreen.tsx
@@ -17,6 +17,7 @@ const UploadScreen = () => {
   const [cvFile, setCvFile] = useState<File | null>(null)
   const [jobs, setJobs] = useState<PocJob[]>([])
   const [jobId, setJobId] = useState('')
+  const [jobDescription, setJobDescription] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
 
@@ -68,11 +69,15 @@ const UploadScreen = () => {
       alert('Please select a job')
       return
     }
+    if (jobDescription.trim().length < 40) {
+      alert('Please paste the job description (at least 40 characters) for skill extraction')
+      return
+    }
 
     setIsLoading(true)
     try {
       const { cvText } = await uploadPdf(cvFile)
-      const result = await analyzeCv(jobId, cvText)
+      const result = await analyzeCv(jobId, cvText, jobDescription)
       sessionStorage.setItem(RESULT_KEY, JSON.stringify(result))
       navigate('/dashboard')
     } catch (err) {
@@ -152,7 +157,7 @@ const UploadScreen = () => {
               </div>
             </div>
 
-            <div className="upload-section">
+            <div className="upload-section upload-section--job">
               <div className="section-header">
                 <span className="section-icon">💼</span>
                 <h2 className="section-title">Select job</h2>
@@ -160,8 +165,7 @@ const UploadScreen = () => {
               {loadError && <p className="textarea-hint" style={{ color: '#b91c1c' }}>{loadError}</p>}
               <select
                 id="job-select"
-                className="job-description-textarea"
-                style={{ minHeight: '3rem', cursor: 'pointer' }}
+                className="job-select"
                 value={jobId}
                 onChange={(e) => setJobId(e.target.value)}
                 disabled={isLoading || jobs.length === 0}
@@ -178,13 +182,37 @@ const UploadScreen = () => {
                 )}
               </select>
               <p className="textarea-hint">Choose one of five predefined roles for this POC.</p>
+
+              <label htmlFor="job-description" className="job-description-label">
+                Job description
+              </label>
+              <textarea
+                id="job-description"
+                className="job-description-textarea job-description-textarea--compact"
+                value={jobDescription}
+                onChange={(e) => setJobDescription(e.target.value)}
+                placeholder="Paste the full job posting (requirements, responsibilities, stack)…"
+                rows={6}
+                disabled={isLoading}
+                required
+                minLength={40}
+              />
+              <p className="textarea-hint">
+                Dynamic skills are extracted from this text.
+              </p>
             </div>
           </div>
 
           <button
             type="submit"
             className="analyze-button"
-            disabled={isLoading || !cvFile || !jobId || !!loadError}
+            disabled={
+              isLoading ||
+              !cvFile ||
+              !jobId ||
+              jobDescription.trim().length < 40 ||
+              !!loadError
+            }
           >
             {isLoading ? 'Analyzing…' : 'Analyze Match →'}
           </button>
@@ -192,10 +220,12 @@ const UploadScreen = () => {
           {!isLoading && (
             <p className="instruction-text">
               {!cvFile
-                ? 'Upload a PDF resume and pick a job to analyze'
+                ? 'Upload a PDF resume, pick a role, and paste a job description'
                 : !jobId
-                  ? 'Select a job, then run the match analysis'
-                  : 'Click Analyze Match to see your score on the next screen'}
+                  ? 'Select a job, paste a job description, then analyze'
+                  : jobDescription.trim().length < 40
+                    ? 'Paste at least 40 characters of job description text'
+                    : 'Click Analyze Match to see your score on the next screen'}
             </p>
           )}
         </form>

--- a/frontend/src/services/README.md
+++ b/frontend/src/services/README.md
@@ -6,7 +6,7 @@ These functions call the **real** backend over HTTP (not mocks).
 |----------|--------|------|---------|
 | `fetchJobs()` | GET | `/api/jobs` | Job list for the upload screen |
 | `uploadPdf(file)` | POST | `/api/upload` | `FormData` field **`file`** → `{ cvText }` |
-| `analyzeCv(jobId, cvText)` | POST | `/api/analyze` | JSON `{ jobId, cvText }` → analyze result |
+| `analyzeCv(jobId, cvText, jobDescription)` | POST | `/api/analyze` | JSON `{ jobId, cvText, jobDescription }` (JD min 40 chars) → analyze result |
 
 Base URL: `import.meta.env.VITE_API_BASE_URL` or **`/api`** (Vite dev proxy to port 8000).
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -52,11 +52,21 @@ export async function uploadPdf(file: File): Promise<UploadPdfResponse> {
   return res.json() as Promise<UploadPdfResponse>
 }
 
-export async function analyzeCv(jobId: string, cvText: string): Promise<AnalyzeResponse> {
+const MIN_JOB_DESCRIPTION_CHARS = 40
+
+export async function analyzeCv(
+  jobId: string,
+  cvText: string,
+  jobDescription: string
+): Promise<AnalyzeResponse> {
+  const jd = jobDescription.trim()
+  if (jd.length < MIN_JOB_DESCRIPTION_CHARS) {
+    throw new Error(`Please paste a job description (at least ${MIN_JOB_DESCRIPTION_CHARS} characters).`)
+  }
   const res = await fetch(`${base()}/analyze`, {
     method: 'POST',
     headers: jsonHeaders,
-    body: JSON.stringify({ jobId, cvText }),
+    body: JSON.stringify({ jobId, cvText, jobDescription: jd }),
   })
   if (!res.ok) {
     const err = await res.json().catch(() => ({}))


### PR DESCRIPTION
## What’s on this branch

This PR combines two POC-focused changes:

1. **`chore(poc): observability logs for OpenAI paths and startup`**  
   Structured logs for dynamic skill extraction and scoring (success/failure, uniform-score fallback), plus startup logging for LLM configuration.

2. **`feat(poc): user-supplied job description for dynamic skills`**  
   Analyze uses client `jobDescription` only (min 40 chars); upload UI places the JD under the role select; seed stores titles only (no DB job descriptions).

---

## User-supplied job description

- `POST /api/analyze` with `jobId` now requires `jobDescription` in the JSON body (trimmed, **minimum 40 characters**).
- `extractDynamicSkills` uses **only** that text. It does **not** read `Job.description` from MongoDB (legacy `jobTitle` + `jobDescription` + `cvText` flow unchanged).
- **Upload screen:** job description textarea sits **directly under** the role dropdown; resume stays in the other column.

## Seed data

- `seed.ts` inserts five jobs with **title + normalizedTitle** only. Re-run `npm run seed` after merge if you want a clean DB.

## Observability (commit above)

- POC logs for OpenAI paths (dynamic skills, scoring) and clearer behavior when the LLM returns uniform scores.
- Startup message for LLM readiness / config.

## Docs

- `docs/POC.md`, `frontend/src/services/README.md`, and `frontend/BACKEND_INTEGRATION.md` updated for the analyze contract.

## How to verify

1. `cd backend && npm run seed` (if needed).
2. Run backend + frontend; upload PDF, pick a role, paste a JD (≥40 chars), **Analyze Match**.
3. Optional: `npm run check-cvs` (uses synthetic JD when DB description is empty).