### PR TITLE
Feat/job url cv only upload

### DIFF
--- a/backend/src/routes/analyze.routes.ts
+++ b/backend/src/routes/analyze.routes.ts
@@ -11,6 +11,8 @@ import { ValidationError } from '../errors';
 import type { IJob } from '../models/job.model';
 import { logAnalyzeOk } from '../utils/pocLog';
 import { isGibberish } from '../utils/gibberishDetector';
+import { looksLikeJobUrl } from '../utils/jobUrl';
+import { fetchJobPostingFromUrl } from '../services/jobPostingFetcher.service';
 import { authenticate } from '../middleware/auth.middleware';
 
 const router = Router();
@@ -155,6 +157,13 @@ export function mergeTenSkills(jobTitle: string, core: string[], dynamic: string
 
 const MIN_JOB_DESCRIPTION_CHARS = 40;
 
+async function resolveJobDescriptionInput(raw: string): Promise<string> {
+  const trimmed = raw.trim();
+  if (!looksLikeJobUrl(trimmed)) return trimmed;
+  const fetched = await fetchJobPostingFromUrl(trimmed);
+  return fetched.description.trim();
+}
+
 /**
  * POST /api/analyze
  *
@@ -177,14 +186,23 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
 
     if (jobId && cvText) {
       job = await validateJobById(jobId);
-      const jd =
-        typeof jobDescription === 'string' ? jobDescription.trim() : '';
-      if (jd.length < MIN_JOB_DESCRIPTION_CHARS) {
-        throw new ValidationError(
-          `jobDescription is required (at least ${MIN_JOB_DESCRIPTION_CHARS} characters) — paste the job posting for skill extraction`
-        );
+      if (skipGibberish) {
+        descriptionForDynamic = '';
+      } else {
+        const jd =
+          typeof jobDescription === 'string' ? jobDescription.trim() : '';
+        if (!jd) {
+          throw new ValidationError(
+            'jobDescription is required — paste the job posting text or a link'
+          );
+        }
+        descriptionForDynamic = await resolveJobDescriptionInput(jd);
+        if (descriptionForDynamic.length < MIN_JOB_DESCRIPTION_CHARS) {
+          throw new ValidationError(
+            `jobDescription is required (at least ${MIN_JOB_DESCRIPTION_CHARS} characters) — paste the job posting for skill extraction`
+          );
+        }
       }
-      descriptionForDynamic = jd;
     } else if (jobTitle && jobDescription && cvText) {
       job = await validateJobTitle(jobTitle);
       descriptionForDynamic = jobDescription;

--- a/backend/src/routes/jobs.routes.ts
+++ b/backend/src/routes/jobs.routes.ts
@@ -2,6 +2,8 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { getAllJobs } from '../dal/job.dal';
 import { extractSkills } from '../agents/skillExtraction.agent';
 import { authenticate } from '../middleware/auth.middleware';
+import { fetchJobPostingFromUrl } from '../services/jobPostingFetcher.service';
+import { ValidationError } from '../errors';
 
 const router = Router();
 router.use(authenticate);
@@ -11,6 +13,20 @@ router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const jobs = await getAllJobs();
     res.json(jobs.map((j) => ({ id: String(j._id), title: j.title })));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /jobs/fetch-description — Fetch job description text from a public posting URL
+router.post('/fetch-description', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { url } = req.body as { url?: string };
+    if (!url || typeof url !== 'string' || !url.trim()) {
+      throw new ValidationError('url is required');
+    }
+    const result = await fetchJobPostingFromUrl(url);
+    res.json(result);
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/jobPostingFetcher.service.ts
+++ b/backend/src/services/jobPostingFetcher.service.ts
@@ -1,0 +1,191 @@
+import axios from 'axios';
+import { UnprocessableError, ValidationError } from '../errors';
+import { htmlToText } from '../utils/htmlToText';
+import { assertSafePublicUrl } from '../utils/urlSafety';
+
+const MIN_EXTRACTED_CHARS = 40;
+const FETCH_TIMEOUT_MS = 15_000;
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; CareerLens/1.0; +https://github.com/yaringol/CareerLens)';
+
+export interface FetchedJobPosting {
+  title?: string;
+  description: string;
+  source: 'comeet' | 'json-ld' | 'html';
+  sourceUrl: string;
+}
+
+interface ComeetDetail {
+  name?: string;
+  value?: string;
+  order?: number;
+}
+
+interface ComeetPosition {
+  name?: string;
+  details?: ComeetDetail[];
+}
+
+function extractRegex(html: string, pattern: RegExp): string | undefined {
+  const match = html.match(pattern);
+  return match?.[1]?.trim();
+}
+
+function parseComeetPath(url: URL): { companyUid: string; positionUid: string } | null {
+  const parts = url.pathname.split('/').filter(Boolean);
+  const jobsIdx = parts.indexOf('jobs');
+  if (jobsIdx < 0 || parts.length < jobsIdx + 5) return null;
+  return {
+    companyUid: parts[jobsIdx + 2],
+    positionUid: parts[jobsIdx + 4],
+  };
+}
+
+function isComeetHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === 'www.comeet.com' || host === 'comeet.com' || host === 'www.comeet.co' || host === 'comeet.co';
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const response = await axios.get<string>(url, {
+    timeout: FETCH_TIMEOUT_MS,
+    maxRedirects: 5,
+    responseType: 'text',
+    headers: { 'User-Agent': USER_AGENT, Accept: 'text/html,application/xhtml+xml' },
+    validateStatus: (status) => status >= 200 && status < 400,
+  });
+  return response.data;
+}
+
+function buildComeetDescription(position: ComeetPosition): string {
+  const chunks: string[] = [];
+  if (position.name) chunks.push(position.name);
+
+  const details = [...(position.details ?? [])].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0)
+  );
+  for (const detail of details) {
+    if (!detail.value) continue;
+    const label = detail.name ? `${detail.name}: ` : '';
+    chunks.push(`${label}${htmlToText(detail.value)}`);
+  }
+
+  return chunks.join('\n\n').trim();
+}
+
+async function fetchFromComeet(url: URL): Promise<FetchedJobPosting> {
+  const ids = parseComeetPath(url);
+  if (!ids) {
+    throw new UnprocessableError('Could not read position id from Comeet link');
+  }
+
+  const pageHtml = await fetchHtml(url.toString());
+  const token =
+    extractRegex(pageHtml, /"token"\s*:\s*"([A-Fa-f0-9]+)"/) ??
+    extractRegex(pageHtml, /token"\s*:\s*"([A-Fa-f0-9]+)"/);
+  const companyUid =
+    extractRegex(pageHtml, /"company_uid"\s*:\s*"([^"]+)"/) ?? ids.companyUid;
+
+  if (!token) {
+    throw new UnprocessableError('Could not read Comeet careers token from the job page');
+  }
+
+  const apiBase = url.hostname.includes('comeet.co') ? 'https://www.comeet.co' : 'https://www.comeet.com';
+  const apiUrl = `${apiBase}/careers-api/2.0/company/${companyUid}/positions/${ids.positionUid}`;
+  const { data } = await axios.get<ComeetPosition>(apiUrl, {
+    timeout: FETCH_TIMEOUT_MS,
+    params: { token, details: true },
+    headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+    validateStatus: (status) => status >= 200 && status < 400,
+  });
+
+  const description = buildComeetDescription(data);
+  if (description.length < MIN_EXTRACTED_CHARS) {
+    throw new UnprocessableError('Comeet job page did not contain enough description text');
+  }
+
+  return {
+    title: data.name,
+    description,
+    source: 'comeet',
+    sourceUrl: url.toString(),
+  };
+}
+
+function extractJsonLdJobPosting(html: string): FetchedJobPosting | null {
+  const scripts = [...html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)];
+  for (const script of scripts) {
+    try {
+      const parsed = JSON.parse(script[1]) as unknown;
+      const nodes = Array.isArray(parsed) ? parsed : [parsed];
+      for (const node of nodes) {
+        if (!node || typeof node !== 'object') continue;
+        const type = (node as { '@type'?: string })['@type'];
+        if (type !== 'JobPosting') continue;
+        const title = (node as { title?: string }).title;
+        const description = (node as { description?: string }).description;
+        if (!description || description.trim().length < MIN_EXTRACTED_CHARS) continue;
+        return {
+          title,
+          description: htmlToText(description),
+          source: 'json-ld',
+          sourceUrl: '',
+        };
+      }
+    } catch {
+      /* try next script block */
+    }
+  }
+  return null;
+}
+
+function extractFromGenericHtml(html: string, pageUrl: string): FetchedJobPosting | null {
+  const jsonLd = extractJsonLdJobPosting(html);
+  if (jsonLd) {
+    return { ...jsonLd, sourceUrl: pageUrl };
+  }
+
+  const ogDescription = extractRegex(
+    html,
+    /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i
+  );
+  const title = extractRegex(html, /<title[^>]*>([^<]+)<\/title>/i);
+  const body = extractRegex(html, /<body[^>]*>([\s\S]*?)<\/body>/i) ?? html;
+  const text = htmlToText(body);
+
+  const description = ogDescription ? htmlToText(ogDescription) : text;
+  if (description.length < MIN_EXTRACTED_CHARS) return null;
+
+  return {
+    title,
+    description,
+    source: 'html',
+    sourceUrl: pageUrl,
+  };
+}
+
+export async function fetchJobPostingFromUrl(rawUrl: string): Promise<FetchedJobPosting> {
+  const url = assertSafePublicUrl(rawUrl);
+
+  try {
+    if (isComeetHost(url.hostname)) {
+      return await fetchFromComeet(url);
+    }
+
+    const html = await fetchHtml(url.toString());
+    const extracted = extractFromGenericHtml(html, url.toString());
+    if (!extracted) {
+      throw new UnprocessableError(
+        'Could not extract a job description from this page. Paste the text manually instead.'
+      );
+    }
+    return extracted;
+  } catch (err) {
+    if (err instanceof ValidationError || err instanceof UnprocessableError) {
+      throw err;
+    }
+    throw new UnprocessableError(
+      'Could not fetch the job posting link. Check the URL or paste the description manually.'
+    );
+  }
+}

--- a/backend/src/services/scoring.service.ts
+++ b/backend/src/services/scoring.service.ts
@@ -140,7 +140,6 @@ export async function scoreAndPersist(req: ScoreRequest): Promise<ICvAnalysis> {
 
   if (req.keywordOnly) {
     baseInput.rawAgentOutput = buildKeywordFallbackJson(validatedSkills, req.cvText);
-    baseInput.isEstimated = true;
     return parseAndSaveAnalysis(baseInput);
   }
 
@@ -154,7 +153,6 @@ export async function scoreAndPersist(req: ScoreRequest): Promise<ICvAnalysis> {
       );
       baseInput.rawAgentOutput = json;
       if (uniformReplacedWithKeywords) {
-        baseInput.isEstimated = true;
         logLlmScoringUniformReplaced(req.jobTitle);
       } else {
         logLlmScoringOk(req.jobTitle);
@@ -168,7 +166,6 @@ export async function scoreAndPersist(req: ScoreRequest): Promise<ICvAnalysis> {
     logFallbackScoring();
     baseInput.isEstimated = true;
     baseInput.rawAgentOutput = buildKeywordFallbackJson(validatedSkills, req.cvText);
-    baseInput.isEstimated = true;
     return await parseAndSaveAnalysis(baseInput);
   }
 }

--- a/backend/src/utils/htmlToText.ts
+++ b/backend/src/utils/htmlToText.ts
@@ -1,0 +1,24 @@
+const ENTITY_MAP: Record<string, string> = {
+  '&nbsp;': ' ',
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+
+export function htmlToText(html: string): string {
+  let text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<\/li>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+
+  for (const [entity, value] of Object.entries(ENTITY_MAP)) {
+    text = text.split(entity).join(value);
+  }
+
+  return text.replace(/\s+/g, ' ').trim();
+}

--- a/backend/src/utils/jobUrl.ts
+++ b/backend/src/utils/jobUrl.ts
@@ -1,0 +1,10 @@
+export function looksLikeJobUrl(text: string): boolean {
+  const trimmed = text.trim();
+  if (!/^https?:\/\//i.test(trimmed)) return false;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/utils/urlSafety.ts
+++ b/backend/src/utils/urlSafety.ts
@@ -1,0 +1,43 @@
+import { ValidationError } from '../errors';
+
+const BLOCKED_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '::1',
+  '[::1]',
+]);
+
+function isPrivateIpv4(host: string): boolean {
+  const parts = host.split('.').map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}
+
+/** Reject URLs that could be used for SSRF against internal networks. */
+export function assertSafePublicUrl(raw: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    throw new ValidationError('Invalid job posting URL');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new ValidationError('Only http and https job links are supported');
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (BLOCKED_HOSTS.has(host) || isPrivateIpv4(host) || host.endsWith('.local')) {
+    throw new ValidationError('Job link host is not allowed');
+  }
+
+  return parsed;
+}

--- a/frontend/src/components/upload/CvUploadSection.tsx
+++ b/frontend/src/components/upload/CvUploadSection.tsx
@@ -7,6 +7,7 @@ import {
   fetchJobs,
   getCvText,
   getMyCVs,
+  MAX_JOB_DESCRIPTION_CHARS,
   MIN_JOB_DESCRIPTION_CHARS,
   uploadPdf,
   type PocJob,
@@ -14,18 +15,24 @@ import {
 } from '../../services/api'
 import ScanLoader from '../ui/ScanLoader'
 import { isGibberish } from '../../utils/gibberishDetector'
+import { looksLikeJobUrl } from '../../utils/jobUrl'
 import '../../pages/UploadScreen.css'
 
 const RESULT_KEY = 'pocAnalysisResult'
 const CV_EXTRACT_ERROR = 'Could not extract text from this PDF'
+
+type JobInputMode = 'posting' | 'cv-only'
 
 type UploadFieldErrors = {
   jobDescription?: string
   cv?: string
 }
 
-function jobDescriptionError(text: string): string | undefined {
+function jobDescriptionError(text: string, mode: JobInputMode): string | undefined {
+  if (mode === 'cv-only') return undefined
   const trimmed = text.trim()
+  if (!trimmed) return 'Paste a job description or posting link'
+  if (looksLikeJobUrl(trimmed)) return undefined
   if (trimmed.length < MIN_JOB_DESCRIPTION_CHARS) {
     return `Minimum ${MIN_JOB_DESCRIPTION_CHARS} characters required`
   }
@@ -54,13 +61,10 @@ function formatDate(iso: string): string {
 }
 
 export interface CvUploadSectionProps {
-  /** Fade/slide-in on the home page when scrolled into view */
   visible?: boolean
-  /** Show ùBack to homeù link (used on /upload route) */
   showBackLink?: boolean
 }
 
-/** Single upload + analyze form ù used on home page and /upload route */
 const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function CvUploadSection(
   { visible = true, showBackLink = false },
   ref,
@@ -75,6 +79,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   const [jobId, setJobId] = useState('')
   const [jobDescription, setJobDescription] = useState('')
   const [fieldErrors, setFieldErrors] = useState<UploadFieldErrors>({})
+  const [jobInputMode, setJobInputMode] = useState<JobInputMode>('posting')
   const [gibberishWarning, setGibberishWarning] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -162,15 +167,30 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   }
 
   const trimmedJobDescription = jobDescription.trim()
-  const hasEnoughDescription = trimmedJobDescription.length >= MIN_JOB_DESCRIPTION_CHARS
+  const isPostingMode = jobInputMode === 'posting'
+  const isJobUrlInput = isPostingMode && looksLikeJobUrl(trimmedJobDescription)
+  const hasEnoughDescription =
+    !isPostingMode
+    || isJobUrlInput
+    || trimmedJobDescription.length >= MIN_JOB_DESCRIPTION_CHARS
   const hasGibberishDescription = useMemo(
-    () => hasEnoughDescription && isGibberish(trimmedJobDescription),
-    [hasEnoughDescription, trimmedJobDescription],
+    () =>
+      isPostingMode
+      && !isJobUrlInput
+      && hasEnoughDescription
+      && isGibberish(trimmedJobDescription),
+    [hasEnoughDescription, isJobUrlInput, isPostingMode, trimmedJobDescription],
   )
 
   useEffect(() => {
     setGibberishWarning(hasGibberishDescription)
   }, [hasGibberishDescription])
+
+  function switchJobInputMode(mode: JobInputMode) {
+    setJobInputMode(mode)
+    setGibberishWarning(false)
+    setFieldErrors((prev) => ({ ...prev, jobDescription: undefined }))
+  }
 
   const jdError = fieldErrors.jobDescription
   const hasCv = !!(cvFile || selectedCvText)
@@ -178,7 +198,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const nextErrors: UploadFieldErrors = {
-      jobDescription: jobDescriptionError(jobDescription),
+      jobDescription: jobDescriptionError(jobDescription, jobInputMode),
       cv: hasCv ? undefined : 'Upload or select a CV to continue',
     }
     setFieldErrors(nextErrors)
@@ -197,7 +217,12 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
       } else {
         cvText = selectedCvText!
       }
-      const result = await analyzeCv(jobId, cvText, jobDescription)
+      const result = await analyzeCv(
+        jobId,
+        cvText,
+        isPostingMode ? trimmedJobDescription : '',
+        { skipGibberish: !isPostingMode },
+      )
       sessionStorage.setItem(RESULT_KEY, JSON.stringify(result))
       navigate('/dashboard', { replace: true })
     } catch (err) {
@@ -205,10 +230,14 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
         setGibberishWarning(true)
         return
       }
-      if (err instanceof ApiError && err.code === 'VALIDATION') {
+      if (
+        err instanceof ApiError
+        && (err.code === 'VALIDATION' || err.code === 'UNPROCESSABLE' || err.status === 422)
+        && isPostingMode
+      ) {
         setFieldErrors((prev) => ({
           ...prev,
-          jobDescription: err.message || jobDescriptionError(jobDescription),
+          jobDescription: err.message || jobDescriptionError(jobDescription, jobInputMode),
         }))
         return
       }
@@ -223,7 +252,9 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   }
 
   const activeCvName = cvFile ? cvFile.name : selectedCvName
-  const canSubmit = hasCv && !!jobId && !jdError && !hasGibberishDescription && !loadError
+  const canSubmit = isPostingMode
+    ? hasCv && !!jobId && !jdError && !hasGibberishDescription && !loadError
+    : hasCv && !!jobId && !loadError
 
   return (
     <section
@@ -289,7 +320,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
                         </div>
                         <p className="dropzone-filename">{cvFile.name}</p>
-                        <p className="dropzone-meta">{formatFileSize(cvFile.size)} ù PDF</p>
+                        <p className="dropzone-meta">{formatFileSize(cvFile.size)} &middot; PDF</p>
                         <button type="button" className="btn-ghost" onClick={() => fileInputRef.current?.click()} disabled={isLoading}>Change file</button>
                       </div>
                       <label className="save-toggle">
@@ -318,7 +349,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>
                       </div>
                       <p className="dropzone-primary">Drop your CV here</p>
-                      <p className="dropzone-secondary">or <span className="dropzone-browse">browse</span> to upload ù PDF only</p>
+                      <p className="dropzone-secondary">or <span className="dropzone-browse">browse</span> to upload &middot; PDF only</p>
                     </div>
                   )}
                   {fieldErrors.cv && cvTab === 'upload' && (
@@ -330,7 +361,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
               {cvTab === 'my-cvs' && (
                 <div className="saved-cvs">
                   {cvsLoading ? (
-                    <p className="saved-cvs-empty">Loadingù</p>
+                    <p className="saved-cvs-empty">Loading...</p>
                   ) : savedCVs.length === 0 ? (
                     <p className="saved-cvs-empty">No saved CVs yet. Upload one first.</p>
                   ) : (
@@ -346,7 +377,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                           </div>
                           <div className="saved-cv-info">
                             <p className="saved-cv-name">{cv.fileName}</p>
-                            <p className="saved-cv-meta">{formatFileSize(cv.fileSizeBytes)} ù {formatDate(cv.uploadedAt)}</p>
+                            <p className="saved-cv-meta">{formatFileSize(cv.fileSizeBytes)} &middot; {formatDate(cv.uploadedAt)}</p>
                           </div>
                           {selectedCvId === cv.cvId && (
                             <svg className="saved-cv-check" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
@@ -381,71 +412,101 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                 </label>
                 <select id="job-select" className="field-select" value={jobId} onChange={(e) => setJobId(e.target.value)} disabled={isLoading || jobs.length === 0} required>
                   {jobs.length === 0 && !loadError
-                    ? <option value="">Loading rolesù</option>
+                    ? <option value="">Loading roles...</option>
                     : jobs.map((j) => <option key={j.id} value={j.id}>{j.title}</option>)}
                 </select>
               </div>
 
-              <div className="field-group field-group--grow">
-                <label className="field-label" htmlFor="job-description">
-                  <span>
-                    Your Dream Job Posting
-                    <span className="field-required" aria-hidden="true"> *</span>
-                  </span>
-                  <span className="field-hint">Found the job? Copy the full description from LinkedIn / company site and paste here.</span>
-                </label>
-                <textarea
-                  id="job-description"
-                  className={`field-textarea${jdError ? ' field-textarea--invalid' : ''}${gibberishWarning ? ' field-textarea--error' : ''}`}
-                  value={jobDescription}
-                  onChange={(e) => {
-                    const value = e.target.value
-                    setJobDescription(value)
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      jobDescription: jobDescriptionError(value),
-                    }))
-                  }}
-                  onBlur={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      jobDescription: jobDescriptionError(jobDescription),
-                    }))
-                  }}
-                  placeholder="Paste the full job description of the position you want to get hired for. We'll score your CV against it and show exactly what to improve."
+              <div className="jd-mode-tabs" role="tablist" aria-label="Job analysis mode">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={isPostingMode}
+                  className={`jd-mode-tab${isPostingMode ? ' jd-mode-tab--active' : ''}`}
+                  onClick={() => switchJobInputMode('posting')}
                   disabled={isLoading}
-                  required
-                  maxLength={700}
-                  minLength={MIN_JOB_DESCRIPTION_CHARS}
-                  aria-invalid={!!jdError || gibberishWarning}
-                  aria-describedby={
-                    gibberishWarning
-                      ? 'job-description-warning'
-                      : jdError
-                        ? 'job-description-error'
-                        : undefined
-                  }
-                />
-                <span className={`char-counter${jdError || gibberishWarning ? ' char-counter--warn' : ''}`}>
-                  {jobDescription.length} / 700
-                </span>
-                {jdError && (
-                  <span id="job-description-error" className="field-inline-error" role="alert">
-                    {jdError}
-                  </span>
-                )}
-                {gibberishWarning && (
-                  <div id="job-description-warning" className="job-description-warning" role="alert">
-                    <div className="job-description-warning__icon" aria-hidden="true">!</div>
-                    <div className="job-description-warning__content">
-                      <p className="job-description-warning__title">This description looks unreadable.</p>
-                      <p className="job-description-warning__text">
-                        Please replace it with a readable English job posting before analyzing.
-                      </p>
-                    </div>
-                  </div>
-                )}
+                >
+                  Job description or URL
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={!isPostingMode}
+                  className={`jd-mode-tab${!isPostingMode ? ' jd-mode-tab--active' : ''}`}
+                  onClick={() => switchJobInputMode('cv-only')}
+                  disabled={isLoading}
+                >
+                  CV only
+                </button>
               </div>
+
+              {isPostingMode ? (
+                <div className="field-group field-group--grow">
+                  <label className="field-label field-label--stacked" htmlFor="job-description">
+                    <span>
+                      Your Dream Job Posting <span className="field-required" aria-hidden="true">*</span>
+                    </span>
+                    <span className="field-hint">
+                      Paste the full description or a job link - the backend fetches the posting when you analyze.
+                    </span>
+                  </label>
+                  <textarea
+                    id="job-description"
+                    className={`field-textarea${jdError ? ' field-textarea--invalid' : ''}${gibberishWarning ? ' field-textarea--error' : ''}`}
+                    value={jobDescription}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      setJobDescription(value)
+                      setFieldErrors((prev) => ({
+                        ...prev,
+                        jobDescription: jobDescriptionError(value, 'posting'),
+                      }))
+                    }}
+                    onBlur={() => {
+                      setFieldErrors((prev) => ({
+                        ...prev,
+                        jobDescription: jobDescriptionError(jobDescription, 'posting'),
+                      }))
+                    }}
+                    placeholder="Paste job description text, or a link like https://www.comeet.com/jobs/company/..."
+                    disabled={isLoading}
+                    required
+                    maxLength={MAX_JOB_DESCRIPTION_CHARS}
+                    minLength={MIN_JOB_DESCRIPTION_CHARS}
+                    aria-invalid={!!jdError || gibberishWarning}
+                    aria-describedby={
+                      gibberishWarning
+                        ? 'job-description-warning'
+                        : jdError
+                          ? 'job-description-error'
+                          : undefined
+                    }
+                  />
+                  <span className={`char-counter${jdError || gibberishWarning ? ' char-counter--warn' : ''}`}>
+                    {isJobUrlInput ? 'Job link ù will import on analyze' : `${jobDescription.length} / ${MAX_JOB_DESCRIPTION_CHARS}`}
+                  </span>
+                  {jdError && (
+                    <span id="job-description-error" className="field-inline-error" role="alert">
+                      {jdError}
+                    </span>
+                  )}
+                  {gibberishWarning && (
+                    <div id="job-description-warning" className="job-description-warning" role="alert">
+                      <div className="job-description-warning__icon" aria-hidden="true">!</div>
+                      <div className="job-description-warning__content">
+                        <p className="job-description-warning__title">This description looks unreadable.</p>
+                        <p className="job-description-warning__text">
+                          Please replace it with a readable English job posting before analyzing.
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="cv-only-mode-hint">
+                  Score your CV against <strong>5 core skills</strong> for the selected role - no job posting needed.
+                </p>
+              )}
             </div>
           </div>
 
@@ -460,10 +521,10 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                   ? 'Upload or select a CV to continue'
                   : !jobId
                     ? 'Select a role'
-                    : hasGibberishDescription
+                    : isPostingMode && hasGibberishDescription
                       ? 'Enter a readable English job description to continue'
-                      : !hasEnoughDescription
-                        ? `Paste at least ${MIN_JOB_DESCRIPTION_CHARS} characters of job description`
+                      : isPostingMode && !hasEnoughDescription
+                        ? `Paste at least ${MIN_JOB_DESCRIPTION_CHARS} characters or a job link`
                         : null}
               </p>
             )}

--- a/frontend/src/components/upload/CvUploadSection.tsx
+++ b/frontend/src/components/upload/CvUploadSection.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useRef, useState } from 'react'
+import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useError } from '../../context/ErrorContext'
 import {
@@ -13,6 +13,7 @@ import {
   type SavedCv,
 } from '../../services/api'
 import ScanLoader from '../ui/ScanLoader'
+import { isGibberish } from '../../utils/gibberishDetector'
 import '../../pages/UploadScreen.css'
 
 const RESULT_KEY = 'pocAnalysisResult'
@@ -74,6 +75,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   const [jobId, setJobId] = useState('')
   const [jobDescription, setJobDescription] = useState('')
   const [fieldErrors, setFieldErrors] = useState<UploadFieldErrors>({})
+  const [gibberishWarning, setGibberishWarning] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [cvTab, setCvTab] = useState<'upload' | 'my-cvs'>('upload')
@@ -159,6 +161,17 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
     }
   }
 
+  const trimmedJobDescription = jobDescription.trim()
+  const hasEnoughDescription = trimmedJobDescription.length >= MIN_JOB_DESCRIPTION_CHARS
+  const hasGibberishDescription = useMemo(
+    () => hasEnoughDescription && isGibberish(trimmedJobDescription),
+    [hasEnoughDescription, trimmedJobDescription],
+  )
+
+  useEffect(() => {
+    setGibberishWarning(hasGibberishDescription)
+  }, [hasGibberishDescription])
+
   const jdError = fieldErrors.jobDescription
   const hasCv = !!(cvFile || selectedCvText)
 
@@ -170,6 +183,10 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
     }
     setFieldErrors(nextErrors)
     if (nextErrors.jobDescription || nextErrors.cv || !jobId) return
+    if (hasGibberishDescription) {
+      setGibberishWarning(true)
+      return
+    }
     setIsLoading(true)
     try {
       let cvText: string
@@ -184,6 +201,10 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
       sessionStorage.setItem(RESULT_KEY, JSON.stringify(result))
       navigate('/dashboard', { replace: true })
     } catch (err) {
+      if (err instanceof ApiError && err.code === 'GIBBERISH_DETECTED') {
+        setGibberishWarning(true)
+        return
+      }
       if (err instanceof ApiError && err.code === 'VALIDATION') {
         setFieldErrors((prev) => ({
           ...prev,
@@ -202,7 +223,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   }
 
   const activeCvName = cvFile ? cvFile.name : selectedCvName
-  const canSubmit = hasCv && !!jobId && !jdError && !loadError
+  const canSubmit = hasCv && !!jobId && !jdError && !hasGibberishDescription && !loadError
 
   return (
     <section
@@ -375,7 +396,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                 </label>
                 <textarea
                   id="job-description"
-                  className={`field-textarea${jdError ? ' field-textarea--invalid' : ''}`}
+                  className={`field-textarea${jdError ? ' field-textarea--invalid' : ''}${gibberishWarning ? ' field-textarea--error' : ''}`}
                   value={jobDescription}
                   onChange={(e) => {
                     const value = e.target.value
@@ -396,16 +417,33 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                   required
                   maxLength={700}
                   minLength={MIN_JOB_DESCRIPTION_CHARS}
-                  aria-invalid={!!jdError}
-                  aria-describedby={jdError ? 'job-description-error' : undefined}
+                  aria-invalid={!!jdError || gibberishWarning}
+                  aria-describedby={
+                    gibberishWarning
+                      ? 'job-description-warning'
+                      : jdError
+                        ? 'job-description-error'
+                        : undefined
+                  }
                 />
-                <span className={`char-counter${jdError ? ' char-counter--warn' : ''}`}>
+                <span className={`char-counter${jdError || gibberishWarning ? ' char-counter--warn' : ''}`}>
                   {jobDescription.length} / 700
                 </span>
                 {jdError && (
                   <span id="job-description-error" className="field-inline-error" role="alert">
                     {jdError}
                   </span>
+                )}
+                {gibberishWarning && (
+                  <div id="job-description-warning" className="job-description-warning" role="alert">
+                    <div className="job-description-warning__icon" aria-hidden="true">!</div>
+                    <div className="job-description-warning__content">
+                      <p className="job-description-warning__title">This description looks unreadable.</p>
+                      <p className="job-description-warning__text">
+                        Please replace it with a readable English job posting before analyzing.
+                      </p>
+                    </div>
+                  </div>
                 )}
               </div>
             </div>
@@ -418,7 +456,15 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
             </button>
             {!canSubmit && !isLoading && !jdError && !fieldErrors.cv && (
               <p className="cta-hint">
-                {!hasCv ? 'Upload or select a CV to continue' : !jobId ? 'Select a role' : null}
+                {!hasCv
+                  ? 'Upload or select a CV to continue'
+                  : !jobId
+                    ? 'Select a role'
+                    : hasGibberishDescription
+                      ? 'Enter a readable English job description to continue'
+                      : !hasEnoughDescription
+                        ? `Paste at least ${MIN_JOB_DESCRIPTION_CHARS} characters of job description`
+                        : null}
               </p>
             )}
           </div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -54,7 +54,7 @@ const HomePage = () => {
           <h1 className="hero-headline">Does your CV match today's job market?</h1>
           <p className="hero-subheadline">
             CareerLens uses a data-science model to extract the key skills from any job posting<br />
-            and score your CV against them — so you know exactly what to improve.
+            and score your CV against them - so you know exactly what to improve.
           </p>
 
           <div className="hero-actions">

--- a/frontend/src/pages/SkillsMatchDashboard.tsx
+++ b/frontend/src/pages/SkillsMatchDashboard.tsx
@@ -412,7 +412,7 @@ const SkillsMatchDashboard = () => {
               {result.cvOnlyMode && (
                 <span className="cv-only-badge">CV-only analysis (5 skills)</span>
               )}
-              {result.isEstimated && (
+              {result.isEstimated && !result.cvOnlyMode && (
                 <span
                   className="estimated-badge"
                   title="Scores were computed with keyword matching because the AI service was unavailable"

--- a/frontend/src/pages/UploadScreen.css
+++ b/frontend/src/pages/UploadScreen.css
@@ -283,14 +283,25 @@
   font-size: 0.875rem;
   font-weight: 600;
   color: var(--color-primary);
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
+  display: block;
 }
 
 .field-required {
   color: var(--color-error);
   font-weight: 700;
+}
+
+.field-label--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.field-label--stacked .field-hint {
+  display: block;
+  width: 100%;
+  line-height: 1.45;
 }
 
 .field-hint {
@@ -441,6 +452,49 @@
   font-size: 0.8125rem;
   color: var(--color-secondary);
   text-align: center;
+}
+
+.jd-mode-tabs {
+  display: flex;
+  gap: 0;
+  margin-top: 0.25rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.jd-mode-tab {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+  font-family: inherit;
+  margin-bottom: -1px;
+}
+
+.jd-mode-tab--active {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent-start);
+}
+
+.jd-mode-tab:hover:not(.jd-mode-tab--active) {
+  color: var(--color-primary);
+}
+
+.cv-only-mode-hint {
+  margin: 0.5rem 0 0;
+  padding: 0.875rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-secondary);
+  background: rgba(139, 124, 246, 0.06);
+  border: 1px solid rgba(139, 124, 246, 0.15);
+  border-radius: var(--radius-input);
 }
 
 .job-description-warning {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -168,8 +168,25 @@ export async function getCvText(cvId: string): Promise<{ cvId: string; cvText: s
 }
 
 export const MIN_JOB_DESCRIPTION_CHARS = 40
+export const MAX_JOB_DESCRIPTION_CHARS = 12_000
 
 export const JOB_DESCRIPTION_MIN_MESSAGE = `Paste at least ${MIN_JOB_DESCRIPTION_CHARS} characters of job description`
+
+export interface FetchedJobPosting {
+  title?: string
+  description: string
+  source: 'comeet' | 'json-ld' | 'html'
+  sourceUrl: string
+}
+
+export async function fetchJobDescriptionFromUrl(url: string): Promise<FetchedJobPosting> {
+  const res = await apiFetch(`${base()}/jobs/fetch-description`, {
+    method: 'POST',
+    headers: { ...jsonHeaders, ...authHeaders() },
+    body: JSON.stringify({ url: url.trim() }),
+  })
+  return res.json() as Promise<FetchedJobPosting>
+}
 
 export async function analyzeCv(
   jobId: string,
@@ -178,7 +195,7 @@ export async function analyzeCv(
   options: { skipGibberish?: boolean } = {}
 ): Promise<AnalyzeResponse> {
   const jd = jobDescription.trim()
-  if (jd.length < MIN_JOB_DESCRIPTION_CHARS) {
+  if (!options.skipGibberish && jd.length < MIN_JOB_DESCRIPTION_CHARS && !/^https?:\/\//i.test(jd)) {
     throw new ApiError(JOB_DESCRIPTION_MIN_MESSAGE, 400, 'VALIDATION')
   }
   const res = await apiFetch(`${base()}/analyze`, {

--- a/frontend/src/utils/jobUrl.ts
+++ b/frontend/src/utils/jobUrl.ts
@@ -1,0 +1,10 @@
+export function looksLikeJobUrl(text: string): boolean {
+  const trimmed = text.trim();
+  if (!/^https?:\/\//i.test(trimmed)) return false;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Extends the upload/analyze flow so users can paste a job posting **or** a public job URL, or skip the posting entirely and run a **CV-only** analysis against the five core skills for a selected role. Also tightens gibberish validation on the upload form and fixes when the “estimated score” badge appears.

## Changes

### Job URL import (backend)
- New `jobPostingFetcher` service that fetches and extracts job description text from public posting URLs.
- **Comeet** links: parses company/position IDs, reads the careers API token from the page, and pulls structured position details.
- **Generic URLs**: falls back to JSON-LD `JobPosting`, `og:description`, or cleaned HTML body text.
- SSRF protection via `urlSafety` (public URLs only) and a 15s fetch timeout.
- New `POST /api/jobs/fetch-description` endpoint for optional client-side preview.
- `POST /api/analyze` resolves URL-shaped `jobDescription` input server-side before skill extraction.

### Upload UI (`CvUploadSection`)
- Tab switcher: **Job description or URL** vs **CV only**.
- Job description field accepts pasted text or an `https://` link; backend imports the posting on analyze.
- Gibberish detection blocks submit and shows an inline warning when the description looks unreadable.
- Max job description length raised to 12,000 characters (URLs exempt from the 40-char minimum on the client).

### CV-only mode
- Analyze without a job posting; scores against the role’s five core skills only.
- Backend accepts `skipGibberish` to skip dynamic skill extraction from a posting.
- Results dashboard shows a **CV-only analysis (5 skills)** badge.

### Scoring badge fix
- “Estimated score” badge now appears only when OpenAI scoring actually fails and keyword fallback is used.
- No longer shown for intentional keyword-only (CV-only) runs or uniform-score keyword replacements.

## Files touched

| Area | Files |
|------|-------|
| Backend | `jobPostingFetcher.service.ts`, `jobs.routes.ts`, `analyze.routes.ts`, `urlSafety.ts`, `htmlToText.ts`, `jobUrl.ts`, `scoring.service.ts` |
| Frontend | `CvUploadSection.tsx`, `UploadScreen.css`, `api.ts`, `jobUrl.ts`, `SkillsMatchDashboard.tsx`, `HomePage.tsx` |

## Test plan

- [ ] **Paste job description** — paste ≥40 chars of readable English text → analyze succeeds, dynamic skills extracted.
- [ ] **Comeet URL** — paste a valid `comeet.com` / `comeet.co` job link → analyze succeeds, description imported server-side.
- [ ] **Generic job URL** — paste a public posting with JSON-LD or readable HTML → analyze succeeds.
- [ ] **Invalid / private URL** — paste a bad or blocked URL → clear validation error, no crash.
- [ ] **Gibberish description** — paste unreadable text → inline warning, Analyze disabled.
- [ ] **CV-only mode** — switch to CV only, select role + CV → analyze succeeds without job posting; dashboard shows CV-only badge, no estimated-score badge.
- [ ] **Estimated badge** — with OpenAI unavailable, run a normal (posting) analyze → estimated-score badge appears; with OpenAI healthy, badge does not appear.
- [ ] **Regression** — saved CV selection, role dropdown, and existing analyze → results flow still work on home and upload routes.