### PR TITLE
fix: pdf-parse types and DS model pymupdf dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,7 +26,6 @@
         "@types/express": "^4.17.21",
         "@types/multer": "^1.4.11",
         "@types/node": "^20.14.12",
-        "@types/pdf-parse": "^1.1.4",
         "nodemon": "^3.1.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.3"
@@ -414,16 +413,6 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
-      }
-    },
-    "node_modules/@types/pdf-parse": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
-      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,6 @@
     "@types/express": "^4.17.21",
     "@types/multer": "^1.4.11",
     "@types/node": "^20.14.12",
-    "@types/pdf-parse": "^1.1.4",
     "nodemon": "^3.1.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3"

--- a/ds/model/requirements.txt
+++ b/ds/model/requirements.txt
@@ -5,5 +5,6 @@ numpy
 scikit-learn
 spacy>=3.8,<3.9
 skillNer==1.0.3
+pymupdf
 ipython
 en-core-web-lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl


### PR DESCRIPTION
## Summary

- Removes `@types/pdf-parse` from backend devDependencies — it shadowed pdf-parse v2's built-in types and caused `ts-node` to crash with `Module '"pdf-parse"' has no exported member 'PDFParse'`
- Adds `pymupdf` to `ds/model/requirements.txt` — required by the milestone-6 CV title pipeline (`fitz` import); without it the DS server fails to start and `/title/match` returns 404

These fixes unblock local dev after merging milestone-3 with milestone-6 (title detection) on `main`.

## Test plan

- [x] `npm run build` passes in `backend/`
- [x] Backend dev server starts without `PDFParse` TypeScript error
- [x] DS model server starts with all routes: `/text/skills`, `/title/skills`, `/title/match`, `/cv/title`
- [x] Upload a CV and confirm title detection + analyze flow completes without "DS model request failed: 404"