### PR TITLE
fix: align role detection with /cv/role and allow analyze for any job…

### DIFF
--- a/backend/src/routes/cv.routes.ts
+++ b/backend/src/routes/cv.routes.ts
@@ -3,7 +3,7 @@ import { Types } from 'mongoose';
 import { uploadMiddleware } from '../middleware/upload';
 import { authenticate } from '../middleware/auth.middleware';
 import { processUpload } from '../services/cv.service';
-import { detectTitleFromCv } from '../services/dsModel';
+import { detectTitleFromCv, rolesToSuggestions } from '../services/dsModel';
 import { CvFile } from '../models/cvFile.model';
 import { ValidationError } from '../errors';
 import {
@@ -15,7 +15,7 @@ import {
 const router = Router();
 router.use(authenticate);
 
-// POST /api/cv/title — Detect 3 role suggestions based on raw CV text.
+// POST /api/cv/title — Detect the most likely role from raw CV text.
 router.post('/cv/title', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { cvText } = req.body as { cvText?: unknown };
@@ -23,7 +23,15 @@ router.post('/cv/title', async (req: Request, res: Response, next: NextFunction)
       throw new ValidationError('cvText must contain at least 50 characters');
     }
 
-    res.json(detectTitleFromCv(cvText));
+    const roles = await detectTitleFromCv(cvText);
+    const suggestions = rolesToSuggestions(roles);
+    const top = suggestions[0];
+    res.json({
+      detectedTitle: top ? top.canonicalTitle : null,
+      confidence: top ? top.confidence : 0,
+      source: top ? 'experience' : 'none',
+      suggestions,
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/dsModel.ts
+++ b/backend/src/services/dsModel.ts
@@ -20,20 +20,21 @@ export interface TitleMatchSuggestion {
   confidence: number;
 }
 
-interface DsTitleMatchResponse {
-  suggestions?: Array<{
-    canonical_title?: unknown;
-    matched_variant?: unknown;
-    confidence?: unknown;
-  }>;
-}
-
 interface CVTitleDetectionResponse {
   job_title: string;
   confidence: number;
 }
 
-export async function detectTitleFromCv(text: string): Promise<string[]> {
+export interface DetectedRole {
+  jobTitle: string;
+  confidence: number;
+}
+
+/**
+ * Calls /cv/role — the classifier maps free text (CV body or a typed title)
+ * to the nearest supported canonical job titles, ranked by confidence.
+ */
+async function classifyRoles(text: string): Promise<DetectedRole[]> {
   try {
     const response = await axios.get<CVTitleDetectionResponse[]>(
       `${DS_MODEL_URL}/cv/role`,
@@ -42,8 +43,12 @@ export async function detectTitleFromCv(text: string): Promise<string[]> {
         timeout: DS_MODEL_TIMEOUT_MS,
       }
     );
-    const jobTitles: string[] = response.data.map(item => item.job_title);
-    return jobTitles;
+    return (response.data ?? [])
+      .map((item) => ({
+        jobTitle: typeof item.job_title === 'string' ? item.job_title.trim() : '',
+        confidence: typeof item.confidence === 'number' ? item.confidence : 0,
+      }))
+      .filter((role) => role.jobTitle);
   } catch (err) {
     if (axios.isAxiosError(err)) {
       if (err.code === 'ECONNREFUSED' || err.code === 'ECONNABORTED') {
@@ -53,6 +58,10 @@ export async function detectTitleFromCv(text: string): Promise<string[]> {
     }
     throw err;
   }
+}
+
+export async function detectTitleFromCv(text: string): Promise<DetectedRole[]> {
+  return classifyRoles(text);
 }
 
 /**
@@ -141,33 +150,24 @@ export async function getCoreSkills(jobTitle: string): Promise<string[] | null> 
   }
 }
 
+export function rolesToSuggestions(roles: DetectedRole[]): TitleMatchSuggestion[] {
+  return roles.slice(0, 3).map((role) => ({
+    canonicalTitle: role.jobTitle,
+    matchedVariant: role.jobTitle,
+    confidence: role.confidence,
+  }));
+}
+
 export async function getTitleMatches(title: string): Promise<{ suggestions: TitleMatchSuggestion[] }> {
-  try {
-    const response = await axios.get<DsTitleMatchResponse>(`${DS_MODEL_URL}/title/match`, {
-      params: { title },
-      timeout: DS_MODEL_TIMEOUT_MS,
-    });
-    const suggestions = (response.data?.suggestions ?? [])
-      .map((suggestion) => ({
-        canonicalTitle: typeof suggestion.canonical_title === 'string' ? suggestion.canonical_title.trim() : '',
-        matchedVariant: typeof suggestion.matched_variant === 'string' ? suggestion.matched_variant.trim() : '',
-        confidence: typeof suggestion.confidence === 'number' ? suggestion.confidence : 0,
-      }))
-      .filter((suggestion) => suggestion.canonicalTitle && suggestion.matchedVariant)
-      .slice(0, 3);
+  const roles = await classifyRoles(title);
+  const suggestions = rolesToSuggestions(roles).map((suggestion) => ({
+    ...suggestion,
+    matchedVariant: title.trim(),
+  }));
 
-    if (suggestions.length === 0) {
-      throw new DsModelError(`DS model returned no title matches for "${title}"`);
-    }
-
-    return { suggestions };
-  } catch (err) {
-    if (axios.isAxiosError(err)) {
-      if (err.code === 'ECONNREFUSED' || err.code === 'ECONNABORTED') {
-        throw new DsModelError('DS model service is unavailable', 503);
-      }
-      throw new DsModelError(`DS model request failed: ${err.message}`);
-    }
-    throw err;
+  if (suggestions.length === 0) {
+    throw new DsModelError(`DS model returned no title matches for "${title}"`);
   }
+
+  return { suggestions };
 }

--- a/backend/src/services/job.service.ts
+++ b/backend/src/services/job.service.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 import { getPocJobsForList, getJobById, getJobByTitle } from '../dal/job.dal';
-import { IJob } from '../models/job.model';
+import { Job, IJob } from '../models/job.model';
 import { getCoreSkills } from './dsModel';
 import { extractSkills } from '../agents/skillExtraction.agent';
 import { ValidationError, NotFoundError, DsModelError } from '../errors';
@@ -123,13 +123,56 @@ export async function extractDynamicSkills(
   }
 }
 
-export async function validateJobTitle(jobTitle: string): Promise<IJob> {
-  // TODO: Replace with vector DB semantic title matching in production
-  const job = await getJobByTitle(jobTitle);
-  if (!job) {
-    throw new NotFoundError(`Job title "${jobTitle}" not found. Must be one of the 5 POC jobs.`);
+function toNormalizedTitle(title: string): string {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Resolves a canonical title to a Job document. Uses MongoDB when already seeded;
+ * otherwise verifies the title with the DS skills model and upserts a Job row.
+ */
+export async function findOrCreateJobByTitle(jobTitle: string): Promise<IJob> {
+  const title = jobTitle.trim();
+  if (!title) {
+    throw new ValidationError('Job title is required');
   }
-  return job;
+
+  const exact = await getJobByTitle(title);
+  if (exact) return exact;
+
+  const byCase = await Job.findOne(
+    { title: { $regex: new RegExp(`^${escapeRegExp(title)}$`, 'i') } },
+    { title: 1, normalizedTitle: 1, description: 1 }
+  );
+  if (byCase) return byCase;
+
+  const coreSkills = await getCoreSkills(title);
+  if (!coreSkills?.length) {
+    throw new NotFoundError(`Job title "${title}" is not supported by the skills model`);
+  }
+
+  const normalizedTitle = toNormalizedTitle(title);
+  const created = await Job.findOneAndUpdate(
+    { normalizedTitle },
+    { $setOnInsert: { title, normalizedTitle, description: '' } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  if (!created) {
+    throw new DsModelError(`Failed to register job title "${title}"`, 503);
+  }
+  return created;
+}
+
+export async function validateJobTitle(jobTitle: string): Promise<IJob> {
+  return findOrCreateJobByTitle(jobTitle);
 }
 
 export async function validateJobById(jobId: string): Promise<IJob> {

--- a/frontend/src/components/upload/CvUploadSection.tsx
+++ b/frontend/src/components/upload/CvUploadSection.tsx
@@ -91,6 +91,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   const [manualTitleQuery, setManualTitleQuery] = useState('')
   const [manualTitleSuggestions, setManualTitleSuggestions] = useState<TitleMatchSuggestion[]>([])
   const [isManualTitleSearching, setIsManualTitleSearching] = useState(false)
+  const [showManualOverride, setShowManualOverride] = useState(false)
   const [jobDescription, setJobDescription] = useState('')
   const [fieldErrors, setFieldErrors] = useState<UploadFieldErrors>({})
   const [jobInputMode, setJobInputMode] = useState<JobInputMode>('posting')
@@ -115,7 +116,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   }, [cvTab, reportError])
 
   useEffect(() => {
-    if (roleDetection.status !== 'not-found') return
+    if (roleDetection.status !== 'not-found' && !showManualOverride) return
     const title = manualTitleQuery.trim()
     if (title.length < 2) {
       setManualTitleSuggestions([])
@@ -145,7 +146,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
       cancelled = true
       window.clearTimeout(timer)
     }
-  }, [manualTitleQuery, reportError, roleDetection.status])
+  }, [manualTitleQuery, reportError, roleDetection.status, showManualOverride])
 
   const clearCvFieldError = () => {
     setFieldErrors((prev) => (prev.cv ? { ...prev, cv: undefined } : prev))
@@ -154,6 +155,7 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   const resetRoleDetection = () => {
     setManualTitleQuery('')
     setManualTitleSuggestions([])
+    setShowManualOverride(false)
     setRoleDetection({ status: 'idle' })
   }
 
@@ -161,14 +163,9 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
     setRoleDetection({ status: 'detecting' })
     try {
       const detected = await detectCvTitle(cvText)
-      if (!detected.detectedTitle) {
-        setRoleDetection({ status: 'not-found' })
-        return
-      }
-
-      const { suggestions } = await matchTitle(detected.detectedTitle)
+      const suggestions = detected.suggestions ?? []
       const bestMatch = suggestions[0]
-      if (!bestMatch) {
+      if (!detected.detectedTitle || !bestMatch) {
         setRoleDetection({ status: 'not-found' })
         return
       }
@@ -195,15 +192,33 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
   }
 
   function selectSuggestedRole(suggestion: TitleMatchSuggestion) {
-    if (roleDetection.status !== 'uncertain' && roleDetection.status !== 'not-found') return
+    const detectedTitle =
+      roleDetection.status === 'uncertain' || roleDetection.status === 'ready'
+        ? roleDetection.detectedTitle
+        : manualTitleQuery.trim() || suggestion.canonicalTitle
     setRoleDetection({
       status: 'ready',
-      detectedTitle: roleDetection.status === 'uncertain'
-        ? roleDetection.detectedTitle
-        : manualTitleQuery.trim(),
+      detectedTitle,
       canonicalTitle: suggestion.canonicalTitle,
       confidence: suggestion.confidence,
     })
+    setShowManualOverride(false)
+    setManualTitleQuery('')
+    setManualTitleSuggestions([])
+  }
+
+  function applyManualRole(title: string) {
+    const trimmed = title.trim()
+    if (!trimmed) return
+    setRoleDetection({
+      status: 'ready',
+      detectedTitle: trimmed,
+      canonicalTitle: trimmed,
+      confidence: 100,
+    })
+    setShowManualOverride(false)
+    setManualTitleQuery('')
+    setManualTitleSuggestions([])
   }
 
   async function detectRoleFromFile(file: File) {
@@ -621,6 +636,75 @@ const CvUploadSection = forwardRef<HTMLElement, CvUploadSectionProps>(function C
                 )}
                 {roleDetection.status === 'error' && (
                   <p className="detected-role detected-role--error">Role detection is unavailable. Please try another CV.</p>
+                )}
+
+                {(roleDetection.status === 'ready'
+                  || roleDetection.status === 'uncertain'
+                  || roleDetection.status === 'error') && (
+                  <div className="role-override">
+                    {!showManualOverride ? (
+                      <button
+                        type="button"
+                        className="role-override__toggle"
+                        onClick={() => setShowManualOverride(true)}
+                        disabled={isLoading}
+                      >
+                        Not the right role? Choose it manually
+                      </button>
+                    ) : (
+                      <div className="role-search">
+                        <p className="role-search__hint">Type your role and pick a match, or use exactly what you typed.</p>
+                        <input
+                          className="role-search__input"
+                          type="search"
+                          value={manualTitleQuery}
+                          onChange={(e) => setManualTitleQuery(e.target.value)}
+                          placeholder="e.g. Software Engineer"
+                          disabled={isLoading}
+                          autoFocus
+                        />
+                        {isManualTitleSearching && <p className="role-search__status">Searching...</p>}
+                        {manualTitleSuggestions.length > 0 && (
+                          <div className="role-suggestions__list" role="list">
+                            {manualTitleSuggestions.map((suggestion) => (
+                              <button
+                                key={suggestion.canonicalTitle}
+                                type="button"
+                                className="role-suggestion"
+                                onClick={() => selectSuggestedRole(suggestion)}
+                                disabled={isLoading}
+                              >
+                                <span>{suggestion.canonicalTitle}</span>
+                                <span>{suggestion.confidence}% match</span>
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                        {manualTitleQuery.trim().length >= 2 && (
+                          <button
+                            type="button"
+                            className="role-override__use"
+                            onClick={() => applyManualRole(manualTitleQuery)}
+                            disabled={isLoading}
+                          >
+                            Use "{manualTitleQuery.trim()}"
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="role-override__cancel"
+                          onClick={() => {
+                            setShowManualOverride(false)
+                            setManualTitleQuery('')
+                            setManualTitleSuggestions([])
+                          }}
+                          disabled={isLoading}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
 

--- a/frontend/src/pages/UploadScreen.css
+++ b/frontend/src/pages/UploadScreen.css
@@ -692,6 +692,71 @@
   border-color: rgba(220, 38, 38, 0.35);
 }
 
+.role-override {
+  margin-top: 0.5rem;
+}
+
+.role-override__toggle {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--color-accent-start);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.role-override__toggle:hover:not(:disabled) {
+  color: var(--color-primary);
+}
+
+.role-override__toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.role-override__use {
+  width: 100%;
+  min-height: 40px;
+  padding: 0.5625rem 0.6875rem;
+  border: 1px solid var(--color-accent-start);
+  border-radius: var(--radius-input);
+  background: rgba(139, 124, 246, 0.08);
+  color: var(--color-accent-start);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.role-override__use:hover:not(:disabled) {
+  background: rgba(139, 124, 246, 0.16);
+}
+
+.role-override__cancel {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--color-secondary);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.role-override__cancel:hover:not(:disabled) {
+  color: var(--color-primary);
+}
+
+.role-override__use:disabled,
+.role-override__cancel:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .field-error {
   font-size: 0.8125rem;
   color: var(--color-error);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -105,6 +105,7 @@ export interface DetectedCvTitle {
   detectedTitle: string | null
   confidence: number
   source: 'headline' | 'experience' | 'none'
+  suggestions: TitleMatchSuggestion[]
 }
 
 export interface TitleMatchSuggestion {


### PR DESCRIPTION
## Summary

- **DS model alignment** — Backend title matching now uses `/cv/role` instead of the removed `/title/match` endpoint (fixes 404 after PR #83 merge).
- **Single-pass CV classification** — Role suggestions come from one full-CV `/cv/role` call; removes the second `matchTitle()` pass that produced wrong options (e.g. Software Engineer CV → Solutions Architect at 95%).
- **Analyze any job title** — `findOrCreateJobByTitle()` auto-registers DS-supported titles in MongoDB (e.g. Project Manager, Qa Engineer), removing the old "Must be one of the 5 POC jobs" blocker.
- **Manual role override** — Upload screen adds "Not the right role? Choose it manually" with search + `Use "…"` so users can pick or type their role when auto-detection is wrong.

## Changed files

| Area | File |
|------|------|
| Backend | `dsModel.ts`, `job.service.ts`, `cv.routes.ts` |
| Frontend | `CvUploadSection.tsx`, `api.ts`, `UploadScreen.css` |

## Test plan

- [ ] Upload `Software_Engineer_strong.pdf` — suggestions should reflect full CV (not Solutions Architect from cert line alone)
- [ ] Pick **Project Manager** or type **Software Engineer** manually — analyze completes without POC job error
- [ ] Click **Not the right role? Choose it manually** → search → `Use "Software Engineer"` → analyze succeeds
- [ ] DS server running with `/cv/role`, `/title/skills`, `/text/skills`