### PR TITLE
Enable focus skill personalization

### DIFF
--- a/backend/src/routes/analyze.routes.ts
+++ b/backend/src/routes/analyze.routes.ts
@@ -362,23 +362,20 @@ type PersonalizationMode = (typeof PERSONALIZATION_MODES)[number];
 /**
  * POST /api/analyze/personalized
  *
- * Contract-only endpoint for the upcoming personalized recommendation flow
- * (Stable / Trending / Personal-Match weighting + focus-skill selection).
- *
- * The time-based / personalized model logic is NOT implemented yet, so a valid
- * request is acknowledged with 501 + PERSONALIZATION_NOT_IMPLEMENTED. The
- * frontend uses this code to offer an explicit fallback to POST /api/analyze.
- * Validation runs first so the request contract is exercised end-to-end today.
+ * Personalized recommendation flow. The selected focus skills become the five
+ * dynamic skill slots while the first five slots stay the canonical core skills.
  */
-router.post('/personalized', (req: Request, res: Response, next: NextFunction) => {
+router.post('/personalized', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { canonicalTitle, cvText, personalization } = req.body as {
+    const { canonicalTitle, cvText, personalization, excludeCvId } = req.body as {
       canonicalTitle?: unknown;
       cvText?: unknown;
+      excludeCvId?: unknown;
       personalization?: {
         mode?: unknown;
         weights?: { stable?: unknown; trending?: unknown; personalMatch?: unknown };
         selectedSkillIds?: unknown;
+        selectedSkillNames?: unknown;
       };
     };
 
@@ -392,7 +389,7 @@ router.post('/personalized', (req: Request, res: Response, next: NextFunction) =
       throw new ValidationError('personalization is required');
     }
 
-    const { mode, weights, selectedSkillIds } = personalization;
+    const { mode, weights, selectedSkillIds, selectedSkillNames } = personalization;
     if (!PERSONALIZATION_MODES.includes(mode as PersonalizationMode)) {
       throw new ValidationError(
         `personalization.mode must be one of: ${PERSONALIZATION_MODES.join(', ')}`
@@ -418,10 +415,53 @@ router.post('/personalized', (req: Request, res: Response, next: NextFunction) =
       throw new ValidationError('You can select up to 5 skills only');
     }
 
-    // Contract validated — personalized model path is not active yet.
-    res.status(501).json({
-      code: 'PERSONALIZATION_NOT_IMPLEMENTED',
-      error: 'Personalized recommendations are not available yet.',
+    if (!Array.isArray(selectedSkillNames)) {
+      throw new ValidationError('personalization.selectedSkillNames must be an array');
+    }
+
+    const focusSkills = selectedSkillNames
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    if (focusSkills.length === 0) {
+      throw new ValidationError('Select at least one focus skill');
+    }
+    if (focusSkills.length > 5) {
+      throw new ValidationError('You can select up to 5 focus skills only');
+    }
+
+    const job = await validateJobTitle(canonicalTitle.trim());
+    const id = job._id.toString();
+    const { coreSkills } = await getCoreSkillsById(id);
+    const allSkills = mergeTenSkills(job.title, coreSkills, focusSkills);
+
+    const { analysis, bestSavedCv } = await analyzeWithParallelFavoriteCompare({
+      userId: req.user!.id,
+      jobId: id,
+      jobTitle: job.title,
+      cvText: cvText.trim(),
+      skills: allSkills,
+      cvOnlyMode: false,
+      expectedSkillCount: 10,
+      excludeCvId: typeof excludeCvId === 'string' ? excludeCvId : undefined,
+      cvFileName: id,
+    });
+
+    logAnalyzeOk(job.title);
+
+    res.json({
+      jobTitle: analysis.jobTitle,
+      skills: analysis.scores.map((s) => ({
+        name: s.skill,
+        score: s.score,
+        trend: 'stable',
+      })),
+      matchScore: analysis.matchScore,
+      id: analysis._id.toString(),
+      cvOnlyMode: analysis.cvOnlyMode ?? false,
+      isEstimated: analysis.isEstimated ?? false,
+      bestSavedCv,
     });
   } catch (err) {
     next(err);

--- a/backend/src/routes/personalize.routes.ts
+++ b/backend/src/routes/personalize.routes.ts
@@ -1,7 +1,11 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { authenticate } from '../middleware/auth.middleware';
 import { ValidationError } from '../errors';
-import { extractTitleFromCv, getSkillsFromText, getCoreSkills } from '../services/dsModel';
+import { extractTitleFromCv, getCoreSkills, getSkillsFromText, getTrendingSkills } from '../services/dsModel';
+import { extractDynamicSkills } from '../services/job.service';
+import { isGibberish } from '../utils/gibberishDetector';
+import { looksLikeJobUrl } from '../utils/jobUrl';
+import { fetchJobPostingFromUrl } from '../services/jobPostingFetcher.service';
 
 const router = Router();
 router.use(authenticate);
@@ -18,6 +22,7 @@ export interface SkillOption {
 
 const ROLE_SKILL_POOL_SIZE = 10;
 const DEFAULT_SELECTED_COUNT = 5;
+const MIN_JOB_DESCRIPTION_CHARS = 40;
 
 function skillId(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
@@ -26,48 +31,80 @@ function skillId(name: string): string {
 /**
  * Build the focus-skill candidate pool for the Personalization screen.
  *
- * The pool is derived ONLY from the role/job itself (deterministic top-N skills
- * for the canonical title), so the user picks from job-relevant skills. CV- and
- * posting-derived skills are intentionally excluded here: they are a product of
- * the personalization the user is about to configure and are not known yet.
- * The top DEFAULT_SELECTED_COUNT are pre-selected.
+ * The pool is derived from the same posting-aware dynamic signals used by
+ * standard analysis: trending market skills first, then LLM/fallback skills
+ * extracted from the job posting. The top DEFAULT_SELECTED_COUNT are pre-selected.
  */
-function buildSkillOptions(roleSkills: string[]): SkillOption[] {
+function tokenSet(s: string): Set<string> {
+  return new Set(
+    s
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length > 2)
+  );
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  if (a.size === 0 || b.size === 0) return 0;
+  let inter = 0;
+  for (const x of a) {
+    if (b.has(x)) inter++;
+  }
+  const union = a.size + b.size - inter;
+  return union ? inter / union : 0;
+}
+
+function isNearDuplicate(skill: string, existing: string[]): boolean {
+  const tokens = tokenSet(skill);
+  if (tokens.size === 0) return true;
+  return existing.some((item) => jaccardSimilarity(tokens, tokenSet(item)) >= 0.5);
+}
+
+function buildSkillOptions(skills: string[], excludedCoreSkills: string[] = []): SkillOption[] {
   const seen = new Set<string>();
   const ordered: string[] = [];
-  for (const raw of roleSkills) {
+  for (const raw of skills) {
     const name = raw.trim();
     const key = name.toLowerCase();
     if (!name || seen.has(key)) continue;
+    if (isNearDuplicate(name, excludedCoreSkills)) continue;
     seen.add(key);
     ordered.push(name);
+    if (ordered.length >= ROLE_SKILL_POOL_SIZE) break;
   }
 
   const total = ordered.length || 1;
   return ordered.map((name, i) => ({
     id: skillId(name) || `skill-${i}`,
     name,
-    source: 'role' as SkillSource,
+    source: 'market' as SkillSource,
     score: Number((1 - i / total).toFixed(2)),
     selectedByDefault: i < DEFAULT_SELECTED_COUNT,
   }));
+}
+
+async function resolveJobDescriptionInput(raw: string): Promise<string> {
+  const trimmed = raw.trim();
+  if (!looksLikeJobUrl(trimmed)) return trimmed;
+  const fetched = await fetchJobPostingFromUrl(trimmed);
+  return fetched.description.trim();
 }
 
 /**
  * POST /api/personalize/options
  *
  * Feeds the Personalization screen with the detected title, the user's
- * CV-extracted skills, and a role-derived focus-skill pool (top
- * ROLE_SKILL_POOL_SIZE for the role, top 5 pre-selected).
- * jobDescription is accepted now so the contract is ready to derive skills from
- * the posting later; it is not used to build the focus pool today.
+ * CV-extracted skills, and a posting-derived focus-skill pool. In CV-only mode
+ * there is no job posting, so no dynamic focus skills are returned.
  */
 router.post('/options', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
-    const { canonicalTitle, cvText } = req.body as {
+    const { canonicalTitle, cvText, jobDescription, isPostingMode } = req.body as {
       canonicalTitle?: unknown;
       cvText?: unknown;
       jobDescription?: unknown;
+      isPostingMode?: unknown;
     };
 
     if (typeof canonicalTitle !== 'string' || !canonicalTitle.trim()) {
@@ -77,16 +114,62 @@ router.post('/options', async (req: Request, res: Response, next: NextFunction):
       throw new ValidationError('cvText is required (min 10 chars)');
     }
 
-    const [titleResult, roleSkills, cvSkills] = await Promise.all([
-      extractTitleFromCv(cvText).catch(() => null),
-      getCoreSkills(canonicalTitle.trim(), 0.0, ROLE_SKILL_POOL_SIZE).catch(() => null),
-      getSkillsFromText(cvText, 15).catch(() => [] as string[]),
+    const postingMode = isPostingMode === true || (
+      isPostingMode !== false &&
+      typeof jobDescription === 'string' &&
+      jobDescription.trim().length > 0
+    );
+
+    const titlePromise = extractTitleFromCv(cvText).catch(() => null);
+    const cvSkillsPromise = getSkillsFromText(cvText, 15).catch(() => [] as string[]);
+    let focusSkillsPromise: Promise<string[]> = Promise.resolve([]);
+
+    if (postingMode) {
+      const rawDescription = typeof jobDescription === 'string' ? jobDescription.trim() : '';
+      if (!rawDescription) {
+        throw new ValidationError('jobDescription is required for focus skills');
+      }
+      const description = await resolveJobDescriptionInput(rawDescription);
+      if (description.length < MIN_JOB_DESCRIPTION_CHARS) {
+        throw new ValidationError(
+          `jobDescription is required (at least ${MIN_JOB_DESCRIPTION_CHARS} characters)`
+        );
+      }
+      if (isGibberish(description)) {
+        res.status(400).json({
+          code: 'GIBBERISH_DETECTED',
+          error: 'The job description does not look like readable English.',
+        });
+        return;
+      }
+
+      focusSkillsPromise = Promise.all([
+        getCoreSkills(canonicalTitle.trim(), 0.0, DEFAULT_SELECTED_COUNT).catch(() => []),
+        getTrendingSkills(canonicalTitle.trim(), ROLE_SKILL_POOL_SIZE).catch(() => []),
+        extractDynamicSkills(canonicalTitle.trim(), description)
+          .then((result) => result.extractedSkills)
+          .catch(() => [] as string[]),
+        getSkillsFromText(description, ROLE_SKILL_POOL_SIZE).catch(() => [] as string[]),
+      ]).then(([core, trending, dynamic, skillNer]) => {
+        const candidates = [
+          ...trending.map((item) => item.skill),
+          ...dynamic,
+          ...skillNer,
+        ];
+        return buildSkillOptions(candidates, core ?? []).map((skill) => skill.name);
+      });
+    }
+
+    const [titleResult, focusSkills, cvSkills] = await Promise.all([
+      titlePromise,
+      focusSkillsPromise,
+      cvSkillsPromise,
     ]);
 
     const detectedTitle =
       titleResult?.canonical_title || titleResult?.extracted_title || canonicalTitle.trim();
     const extractedCvSkills = cvSkills ?? [];
-    const roleDerivedSkills = buildSkillOptions(roleSkills ?? []);
+    const roleDerivedSkills = buildSkillOptions(focusSkills ?? []);
 
     res.json({ detectedTitle, extractedCvSkills, roleDerivedSkills });
   } catch (err) {

--- a/frontend/src/pages/PersonalizationScreen.tsx
+++ b/frontend/src/pages/PersonalizationScreen.tsx
@@ -122,6 +122,7 @@ export default function PersonalizationScreen() {
       canonicalTitle: input.canonicalTitle,
       cvText: input.cvText,
       jobDescription: input.jobDescription || undefined,
+      isPostingMode: input.isPostingMode,
     })
       .then((data) => {
         if (cancelled) return
@@ -167,13 +168,23 @@ export default function PersonalizationScreen() {
     if (!input || submitting) return
     setSubmitting(true)
     try {
-      await analyzePersonalized({
+      const selectedSkillNames = (options?.roleDerivedSkills ?? [])
+        .filter((skill) => selectedIds.includes(skill.id))
+        .map((skill) => skill.name)
+      const result = await analyzePersonalized({
         canonicalTitle: input.canonicalTitle,
         cvText: input.cvText,
         jobDescription: input.jobDescription || undefined,
-        personalization: { mode, weights, selectedSkillIds: selectedIds },
+        excludeCvId: input.excludeCvId || undefined,
+        personalization: { mode, weights, selectedSkillIds: selectedIds, selectedSkillNames },
       })
-      // Future: personalized results flow. Not reachable while backend returns 501.
+      sessionStorage.setItem(
+        RESULT_KEY,
+        JSON.stringify({ ...result, cvText: input.cvText, cvFileName: input.cvFileName })
+      )
+      sessionStorage.setItem('jobDescription', input.isPostingMode ? input.jobDescription : '')
+      sessionStorage.setItem('cvFileName', input.cvFileName)
+      sessionStorage.setItem('excludeCvId', input.excludeCvId ?? '')
       navigate('/dashboard', { replace: true })
     } catch (err) {
       if (err instanceof ApiError && err.code === 'PERSONALIZATION_NOT_IMPLEMENTED') {
@@ -218,6 +229,7 @@ export default function PersonalizationScreen() {
 
   const detectedTitle = options?.detectedTitle ?? input.detectedTitle ?? input.canonicalTitle
   const selectedCount = selectedIds.length
+  const showFocusSkills = input.isPostingMode
 
   return (
     <section className="upload-section upload-section--visible">
@@ -292,44 +304,43 @@ export default function PersonalizationScreen() {
           )}
         </section>
 
-        {/* ── Area 2: Focus Skills ─────────────────────────────────── */}
-        <section className="personalize-section">
-          <h2 className="personalize-section-title">Focus Skills</h2>
-          <p className="personalize-section-sub">
-            Skills derived from <strong>this specific role</strong> ({detectedTitle}). Pick up to{' '}
-            {MAX_FOCUS_SKILLS} to focus on — only the selected ones move to your results.{' '}
-            <span className="focus-count">({selectedCount}/{MAX_FOCUS_SKILLS} selected)</span>
-          </p>
+        {showFocusSkills && (
+          <section className="personalize-section">
+            <h2 className="personalize-section-title">Focus Skills</h2>
+            <p className="personalize-section-sub">
+              Top dynamic skills extracted from this job posting. Pick up to{' '}
+              {MAX_FOCUS_SKILLS} to focus on — only the selected ones move to your results.{' '}
+              <span className="focus-count">({selectedCount}/{MAX_FOCUS_SKILLS} selected)</span>
+            </p>
 
-          {loadingOptions ? (
-            <p className="personalize-loading">Loading skills…</p>
-          ) : options && options.roleDerivedSkills.length > 0 ? (
-            <div className="focus-skill-grid">
-              {options.roleDerivedSkills.map((skill) => {
-                const checked = selectedIds.includes(skill.id)
-                const atLimit = !checked && selectedCount >= MAX_FOCUS_SKILLS
-                return (
-                  <button
-                    key={skill.id}
-                    type="button"
-                    className={`focus-skill-chip${checked ? ' focus-skill-chip--selected' : ''}${atLimit ? ' focus-skill-chip--disabled' : ''}`}
-                    onClick={() => toggleSkill(skill)}
-                    aria-pressed={checked}
-                  >
-                    <span className="focus-skill-name">{skill.name}</span>
-                    {skill.source !== 'role' && (
+            {loadingOptions ? (
+              <p className="personalize-loading">Loading skills…</p>
+            ) : options && options.roleDerivedSkills.length > 0 ? (
+              <div className="focus-skill-grid">
+                {options.roleDerivedSkills.map((skill) => {
+                  const checked = selectedIds.includes(skill.id)
+                  const atLimit = !checked && selectedCount >= MAX_FOCUS_SKILLS
+                  return (
+                    <button
+                      key={skill.id}
+                      type="button"
+                      className={`focus-skill-chip${checked ? ' focus-skill-chip--selected' : ''}${atLimit ? ' focus-skill-chip--disabled' : ''}`}
+                      onClick={() => toggleSkill(skill)}
+                      aria-pressed={checked}
+                    >
+                      <span className="focus-skill-name">{skill.name}</span>
                       <span className={`focus-skill-source focus-skill-source--${skill.source}`}>
                         {skill.source === 'cv' ? 'from CV' : 'from posting'}
                       </span>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          ) : (
-            <p className="personalize-loading">No skills available for this role.</p>
-          )}
-        </section>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="personalize-loading">No dynamic skills available for this posting.</p>
+            )}
+          </section>
+        )}
 
         {/* ── Footer / actions ─────────────────────────────────────── */}
         {notImplemented ? (

--- a/frontend/src/pages/SkillsMatchDashboard.css
+++ b/frontend/src/pages/SkillsMatchDashboard.css
@@ -174,6 +174,33 @@
   gap: 0.5rem;
 }
 
+.card-eyebrow-row--spaced {
+  justify-content: space-between;
+}
+
+.btn-card-mini {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid rgba(139, 116, 246, 0.35);
+  border-radius: var(--radius-full);
+  background: rgba(139, 116, 246, 0.1);
+  color: var(--color-accent-start);
+  font-family: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, transform 0.15s;
+}
+
+.btn-card-mini:hover {
+  background: rgba(139, 116, 246, 0.16);
+  border-color: rgba(139, 116, 246, 0.55);
+  transform: translateY(-1px);
+}
+
 .estimated-badge {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/SkillsMatchDashboard.tsx
+++ b/frontend/src/pages/SkillsMatchDashboard.tsx
@@ -11,6 +11,7 @@ import './SkillsMatchDashboard.css'
 
 const RESULT_KEY = 'analysisResult'
 const CV_FILENAME_KEY = 'cvFileName'
+const PERSONALIZATION_INPUT_KEY = 'personalizationInput'
 
 type StoredAnalysisResult = AnalyzeResponse & {
   cvText?: string
@@ -450,6 +451,7 @@ const SkillsMatchDashboard = () => {
   const dynamicSkills = result.skills.slice(5, 10)
   const matchPercent  = Math.round((result.matchScore / 10) * 100)
   const analyzedSkillCount = result.cvOnlyMode ? 5 : 10
+  const canCustomize = !result.cvOnlyMode && Boolean(sessionStorage.getItem(PERSONALIZATION_INPUT_KEY))
 
   return (
     <div className="dashboard-screen">
@@ -569,10 +571,21 @@ const SkillsMatchDashboard = () => {
           {/* ── Dynamic skills card ── */}
           {!result.cvOnlyMode && (
             <ScoreCard>
-              <p className="card-eyebrow">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-                Dynamic Skills
-              </p>
+              <div className="card-eyebrow-row card-eyebrow-row--spaced">
+                <p className="card-eyebrow">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+                  Dynamic Skills
+                </p>
+                {canCustomize && (
+                  <button
+                    type="button"
+                    className="btn-card-mini"
+                    onClick={() => navigate('/personalize')}
+                  >
+                    Customize
+                  </button>
+                )}
+              </div>
               <div className="skills-list">
                 {dynamicSkills.map((s, i) => (
                   <SkillRow key={s.name} name={s.name} score={s.score} max={10} delay={500 + i * 80} />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -157,10 +157,12 @@ export interface PersonalizationContract {
   canonicalTitle: string
   cvText: string
   jobDescription?: string
+  excludeCvId?: string
   personalization: {
     mode: RecommendationMode
     weights: PersonalizationWeights
     selectedSkillIds: string[]
+    selectedSkillNames?: string[]
   }
 }
 
@@ -331,12 +333,13 @@ export async function analyzeCv(
 
 /**
  * Fetch the data the Personalization screen renders: detected title, the user's
- * CV-extracted skills, and the role-derived focus-skill pool (top 5 pre-selected).
+ * CV-extracted skills, and, in posting mode, the dynamic focus-skill pool.
  */
 export async function getPersonalizationOptions(payload: {
   canonicalTitle: string
   cvText: string
   jobDescription?: string
+  isPostingMode?: boolean
 }): Promise<PersonalizationOptions> {
   const res = await apiFetch(`${base()}/personalize/options`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Implement personalized focus-skill analysis instead of returning the placeholder flow.
- Build focus skill options from posting-derived dynamic skills and filter out core-skill duplicates.
- Hide focus skills for CV-only analysis, where dynamic skills are not available.
- Add a Customize button from the Dynamic Skills results card back to the personalization screen.

## Testing
- npm run build (backend)
- npm run build (frontend)