### PR TITLE
refactor: remove focus skill source display from PersonalizationScreen

### DIFF
--- a/frontend/src/pages/PersonalizationScreen.css
+++ b/frontend/src/pages/PersonalizationScreen.css
@@ -161,19 +161,6 @@
   font-weight: 500;
 }
 
-.focus-skill-source {
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  color: var(--color-secondary);
-  background: var(--color-bg);
-  border-radius: var(--radius-badge);
-  padding: 0.08rem 0.35rem;
-}
-
-.focus-skill-source--cv { color: var(--color-success); }
-.focus-skill-source--market { color: var(--color-accent); }
-
 .personalize-loading {
   margin-top: 0.9rem;
   font-size: 0.88rem;

--- a/frontend/src/pages/PersonalizationScreen.tsx
+++ b/frontend/src/pages/PersonalizationScreen.tsx
@@ -534,9 +534,6 @@ export default function PersonalizationScreen() {
                       aria-pressed={checked}
                     >
                       <span className="focus-skill-name">{skill.name}</span>
-                      <span className={`focus-skill-source focus-skill-source--${skill.source}`}>
-                        {skill.source === 'cv' ? 'from CV' : 'from posting'}
-                      </span>
                     </button>
                   )
                 })}


### PR DESCRIPTION
Eliminated the focus skill source elements from both the CSS and the PersonalizationScreen component to streamline the UI and improve clarity.