### PR TITLE
feat(improve): styled PDF export with selectable design templates

### DIFF
--- a/backend/src/agents/cvStructure.agent.ts
+++ b/backend/src/agents/cvStructure.agent.ts
@@ -1,0 +1,220 @@
+import { llmCall } from '../infra/llm/llmCall';
+import { parseJsonSafe } from '../infra/llm/parseJson';
+import { AgentError } from './agentError';
+
+const AGENT_NAME = 'cvStructure';
+
+// Structuring a full CV into JSON produces far more output than the default
+// 500-token budget; a truncated object here fails the whole PDF export.
+const STRUCTURE_MAX_TOKENS = 3000;
+const STRUCTURE_TIMEOUT_MS = 45000;
+
+export interface StructuredCvContact {
+  email?: string;
+  phone?: string;
+  location?: string;
+  linkedin?: string;
+  github?: string;
+  website?: string;
+}
+
+export interface StructuredCvExperience {
+  title: string;
+  company?: string;
+  location?: string;
+  dates?: string;
+  bullets: string[];
+}
+
+export interface StructuredCvEducation {
+  degree: string;
+  institution?: string;
+  dates?: string;
+  details: string[];
+}
+
+export interface StructuredCvProject {
+  name: string;
+  dates?: string;
+  bullets: string[];
+}
+
+export interface StructuredCvSkillGroup {
+  category?: string;
+  items: string[];
+}
+
+export interface StructuredCvExtraSection {
+  label: string;
+  items: string[];
+}
+
+/**
+ * The typed layout contract between the structuring agent and the PDF
+ * template. Keep in sync with frontend/src/pdf/cvPdfTypes.ts.
+ */
+export interface StructuredCv {
+  name: string;
+  headline?: string;
+  contact: StructuredCvContact;
+  summary?: string;
+  skills: StructuredCvSkillGroup[];
+  experience: StructuredCvExperience[];
+  education: StructuredCvEducation[];
+  projects: StructuredCvProject[];
+  certifications: string[];
+  languages: string[];
+  extras: StructuredCvExtraSection[];
+}
+
+const SYSTEM_PROMPT = `You are a CV layout analyst. You convert the plain text of a CV into a structured JSON object that a design template will render as a polished PDF.
+
+You are an ORGANIZER, not a writer:
+- Every piece of information in the CV text must appear somewhere in the JSON. Never drop content - not even text that looks garbled, misplaced, or like a typo. If a line contains stray characters (e.g. "xxxCore Skills"), carry the stray text through verbatim rather than cleaning it away.
+- Never invent, embellish, or rewrite content. Copy the candidate's wording verbatim; you may only trim leading bullet characters (•, -, *) and fix stray whitespace.
+- Never fabricate contact details, dates, employers, or skills that are not in the text.
+- A skills section may contain full descriptive sentences (e.g. "Basic familiarity with React in collaborative settings.") in addition to skill names - keep each such sentence as its own item in that group's "items"; do not drop, merge, or shorten them.
+
+Return ONLY a JSON object with this exact shape (omit optional string fields you cannot fill; keep empty arrays for sections the CV does not have):
+{
+  "name": "candidate full name",
+  "headline": "professional title, e.g. 'DevOps Engineer' (optional)",
+  "contact": { "email": "", "phone": "", "location": "", "linkedin": "", "github": "", "website": "" },
+  "summary": "the summary/profile/objective paragraph (optional)",
+  "skills": [ { "category": "group name if the CV groups skills (optional)", "items": ["skill", ...] } ],
+  "experience": [ { "title": "role title", "company": "", "location": "", "dates": "", "bullets": ["achievement or responsibility", ...] } ],
+  "education": [ { "degree": "", "institution": "", "dates": "", "details": ["extra line", ...] } ],
+  "projects": [ { "name": "", "dates": "", "bullets": ["", ...] } ],
+  "certifications": ["", ...],
+  "languages": ["English (fluent)", ...],
+  "extras": [ { "label": "section heading, e.g. 'Military Service' or 'Volunteering'", "items": ["", ...] } ]
+}
+
+Parsing rules:
+- Split experience prose into concise bullets at sentence or clause boundaries WITHOUT changing the words themselves.
+- Skills listed as comma/pipe-separated text become individual items.
+- "linkedin"/"github"/"website" hold the URL or handle exactly as written.
+- Any section that fits none of the named groups (awards, publications, hobbies, military service, volunteering...) goes to "extras" with its heading as "label".
+- Output discipline: return ONLY valid JSON - no explanation, no markdown fences.`;
+
+function cleanString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function cleanStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter(Boolean);
+}
+
+function cleanContact(value: unknown): StructuredCvContact {
+  if (!value || typeof value !== 'object') return {};
+  const raw = value as Record<string, unknown>;
+  return {
+    email: cleanString(raw.email),
+    phone: cleanString(raw.phone),
+    location: cleanString(raw.location),
+    linkedin: cleanString(raw.linkedin),
+    github: cleanString(raw.github),
+    website: cleanString(raw.website),
+  };
+}
+
+function cleanObjectArray<T>(value: unknown, map: (raw: Record<string, unknown>) => T | null): T[] {
+  if (!Array.isArray(value)) return [];
+  const out: T[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const mapped = map(item as Record<string, unknown>);
+    if (mapped) out.push(mapped);
+  }
+  return out;
+}
+
+/**
+ * The LLM output is untrusted: coerce every field to the declared shape so the
+ * PDF template never meets a missing array or a non-string bullet.
+ */
+function normalize(parsed: Record<string, unknown>, cvText: string): StructuredCv {
+  const fallbackName = cvText
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean) ?? 'Candidate';
+
+  return {
+    name: cleanString(parsed.name) ?? fallbackName,
+    headline: cleanString(parsed.headline),
+    contact: cleanContact(parsed.contact),
+    summary: cleanString(parsed.summary),
+    skills: cleanObjectArray<StructuredCvSkillGroup>(parsed.skills, (raw) => {
+      const items = cleanStringArray(raw.items);
+      return items.length ? { category: cleanString(raw.category), items } : null;
+    }),
+    experience: cleanObjectArray<StructuredCvExperience>(parsed.experience, (raw) => {
+      const title = cleanString(raw.title);
+      if (!title) return null;
+      return {
+        title,
+        company: cleanString(raw.company),
+        location: cleanString(raw.location),
+        dates: cleanString(raw.dates),
+        bullets: cleanStringArray(raw.bullets),
+      };
+    }),
+    education: cleanObjectArray<StructuredCvEducation>(parsed.education, (raw) => {
+      const degree = cleanString(raw.degree);
+      if (!degree) return null;
+      return {
+        degree,
+        institution: cleanString(raw.institution),
+        dates: cleanString(raw.dates),
+        details: cleanStringArray(raw.details),
+      };
+    }),
+    projects: cleanObjectArray<StructuredCvProject>(parsed.projects, (raw) => {
+      const name = cleanString(raw.name);
+      if (!name) return null;
+      return { name, dates: cleanString(raw.dates), bullets: cleanStringArray(raw.bullets) };
+    }),
+    certifications: cleanStringArray(parsed.certifications),
+    languages: cleanStringArray(parsed.languages),
+    extras: cleanObjectArray<StructuredCvExtraSection>(parsed.extras, (raw) => {
+      const label = cleanString(raw.label);
+      const items = cleanStringArray(raw.items);
+      return label && items.length ? { label, items } : null;
+    }),
+  };
+}
+
+/** Convert improved CV plain text into the typed layout the PDF template renders. */
+export async function structureCv(cvText: string, jobTitle?: string): Promise<StructuredCv> {
+  const targetLine = jobTitle ? `Target job title (context only, do NOT inject it into the CV): ${jobTitle}\n\n` : '';
+
+  const raw = await llmCall(
+    AGENT_NAME,
+    [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: `${targetLine}CV text:\n${cvText}` },
+    ],
+    { maxTokens: STRUCTURE_MAX_TOKENS, timeoutMs: STRUCTURE_TIMEOUT_MS }
+  );
+
+  const parsed = await parseJsonSafe<Record<string, unknown>>(raw, AGENT_NAME);
+  const structured = normalize(parsed, cvText);
+
+  const hasBody =
+    structured.summary ||
+    structured.skills.length ||
+    structured.experience.length ||
+    structured.education.length ||
+    structured.projects.length ||
+    structured.extras.length;
+  if (!hasBody) {
+    throw new AgentError(AGENT_NAME, 'Structured CV came back empty - no sections were recognized');
+  }
+
+  return structured;
+}

--- a/backend/src/routes/cvImprove.routes.ts
+++ b/backend/src/routes/cvImprove.routes.ts
@@ -7,6 +7,7 @@ import {
   rephraseSkill,
   type Proficiency,
 } from '../agents/suggestions.agent';
+import { structureCv } from '../agents/cvStructure.agent';
 import { ImprovementSession } from '../models/improvementSession.model';
 import { NotFoundError, ValidationError } from '../errors';
 
@@ -166,6 +167,29 @@ router.post('/merge', async (req: Request, res: Response, next: NextFunction) =>
 
     const mergedCvText = composeCvFromSections({ sections });
     res.json({ mergedCvText });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/cv-improve/structure
+ * Converts the final CV text into the typed layout used by the designed PDF export.
+ */
+router.post('/structure', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { cvText, jobTitle } = req.body as { cvText?: string; jobTitle?: string };
+
+    if (!cvText || typeof cvText !== 'string' || cvText.trim().length < 50) {
+      throw new ValidationError('cvText is required (min 50 chars)');
+    }
+
+    const structured = await structureCv(
+      cvText.trim(),
+      typeof jobTitle === 'string' && jobTitle.trim() ? jobTitle.trim() : undefined
+    );
+
+    res.json({ structured });
   } catch (err) {
     next(err);
   }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# esbuild artifacts of the dev scripts in scripts/
+scripts/.*.cjs

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource/inter": "^5.3.0",
+        "@react-pdf/renderer": "^4.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.20.0"
@@ -278,6 +280,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -815,6 +826,15 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@fontsource/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -927,6 +947,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -963,6 +1007,183 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.9.tgz",
+      "integrity": "sha512-aKi0+c5MCRfAQtKllCB8KHKW9eM4ybkUBtI7mF5J8Ogbp/FuLJGAmZP/ZWI/EgxepFJe0ryn96Bt9drjO5HjbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^6.0.0",
+        "@react-pdf/types": "^2.11.2",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.1.tgz",
+      "integrity": "sha512-pbeb2qUs+lDZsvNpWSjoVkAm10WjXsoYd5jIB3utqkfWwwMkh3qo2Iz4By08AptAcRINPXaG6ICT3zsrXBMb6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.7.0.tgz",
+      "integrity": "sha512-snTm+6TLPz5U/PDeTu4id5ZuUBD+o7F3W/iHSFuS1Ue10aXpt05bcJICFwsaUZOyCHL1JZazAgqyI/gLW6iqkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.2",
+        "@react-pdf/textkit": "^6.4.0",
+        "@react-pdf/types": "^2.11.2",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-6.0.0.tgz",
+      "integrity": "sha512-VG4L83leBinqnBKIdWSm3REdtEpMh38zcj09kOgqP+w6kNW+mIWSBhAtgOPjKJYWnbh5vSipZ9RIspyRXZV/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "pako": "^1.0.11",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.6.0.tgz",
+      "integrity": "sha512-ZDT7CZWOplU7vI4TfrD1PHHgz6F20G0yeORt+qyBzgADMBzjaKLkhr10rkYn3IlRhUhosXLxWyg/R56z/AFAzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.4.0",
+        "@react-pdf/types": "^2.11.2",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.6.0.tgz",
+      "integrity": "sha512-6dgzuO/46I2jySQjfmzagCJSrjKAOjpihca0BNqFrrP/HK1jg7+/UTTukI0BlZMIkBUm2b0mapoRZTrtF0Uv4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.9",
+        "@react-pdf/layout": "^4.7.0",
+        "@react-pdf/pdfkit": "^6.0.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.6.0",
+        "@react-pdf/types": "^2.11.2",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.2.tgz",
+      "integrity": "sha512-w0BY4WCHhEfLuQQU7fAwdZcaVnWMviO4bIiC+F2rhGYVcQsIin0FtO92W3PQE6QVKeG9jGmATPiKuSSx7NP+MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.2",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.4.0.tgz",
+      "integrity": "sha512-+5JZC5j2Q7cBDxYy7qrb2dGhDHexjwUlavAZkzGQbSQlZbrxHn75/oZ6REhlHk0hmTKEu6SXyycq1AnUd75XUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.2.tgz",
+      "integrity": "sha512-Fb62VHChxq40+SbATjOIqc+x8rncng2Yt/k1Cks7UteCYQf4kdY32koGhuC9SlK6PB5p7Q2F+vjC/mYaJ4WgnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.9",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.2"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1331,6 +1552,15 @@
         "win32"
       ]
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1651,6 +1881,12 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1741,6 +1977,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
@@ -1749,6 +2005,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1772,6 +2037,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -1856,6 +2139,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1875,6 +2167,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1937,6 +2250,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1969,6 +2288,12 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2230,11 +2555,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2290,6 +2623,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -2355,6 +2694,23 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2501,6 +2857,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2554,7 +2931,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-extglob": {
@@ -2600,12 +2976,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2697,6 +3094,25 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2741,6 +3157,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2822,6 +3244,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2882,6 +3322,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2894,6 +3340,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -2955,6 +3407,14 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -2984,6 +3444,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2994,6 +3460,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3002,6 +3479,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -3050,6 +3536,12 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3092,6 +3584,15 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3101,6 +3602,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -3199,6 +3706,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3264,6 +3791,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3303,11 +3839,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -3335,6 +3883,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3376,6 +3930,32 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3416,6 +3996,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -3477,6 +4063,20 @@
         }
       }
     },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3529,6 +4129,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource/inter": "^5.3.0",
+    "@react-pdf/renderer": "^4.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0"

--- a/frontend/scripts/render-cv-pdf-sample.tsx
+++ b/frontend/scripts/render-cv-pdf-sample.tsx
@@ -1,0 +1,158 @@
+/**
+ * Dev preview for the CV PDF template: renders CvPdfDocument with realistic
+ * sample data (a short one-pager and a long two-pager) so design changes can
+ * be reviewed without running the full app.
+ *
+ * Usage (from frontend/):
+ *   node node_modules/esbuild/bin/esbuild scripts/render-cv-pdf-sample.tsx \
+ *     --bundle --platform=node --format=cjs --jsx=automatic \
+ *     --outfile=scripts/.render-cv-pdf-sample.cjs
+ *   node scripts/.render-cv-pdf-sample.cjs [outputDir]
+ */
+import path from 'node:path'
+import React from 'react'
+import { Font, renderToFile } from '@react-pdf/renderer'
+import CvPdfDocument from '../src/pdf/CvPdfDocument'
+import type { StructuredCv } from '../src/pdf/cvPdfTypes'
+
+const FONT_DIR = path.resolve(__dirname, '../node_modules/@fontsource/inter/files')
+
+Font.register({
+  family: 'Inter',
+  fonts: [
+    { src: path.join(FONT_DIR, 'inter-latin-400-normal.woff'), fontWeight: 400 },
+    { src: path.join(FONT_DIR, 'inter-latin-500-normal.woff'), fontWeight: 500 },
+    { src: path.join(FONT_DIR, 'inter-latin-600-normal.woff'), fontWeight: 600 },
+    { src: path.join(FONT_DIR, 'inter-latin-700-normal.woff'), fontWeight: 700 },
+  ],
+})
+
+const sample: StructuredCv = {
+  name: 'John Smith',
+  headline: 'DevOps Engineer',
+  contact: {
+    email: 'john.smith@email.com',
+    phone: '+972-52-123-4567',
+    location: 'Tel Aviv, Israel',
+    linkedin: 'https://www.linkedin.com/in/john-smith-devops',
+    github: 'https://github.com/johnsmith',
+  },
+  summary:
+    'DevOps engineer with 5 years of experience building CI/CD pipelines, automating infrastructure and improving deployment reliability across cloud environments. Passionate about developer experience, observability and shipping infrastructure as code that teams can actually maintain.',
+  skills: [
+    {
+      category: 'Cloud & Infrastructure',
+      items: ['AWS', 'Terraform', 'Kubernetes', 'Docker', 'Linux'],
+    },
+    {
+      category: 'CI/CD & Automation',
+      items: ['Jenkins', 'GitHub Actions', 'ArgoCD', 'Ansible'],
+    },
+    {
+      category: 'Monitoring & Scripting',
+      items: ['Prometheus', 'Grafana', 'Python', 'Bash'],
+    },
+  ],
+  experience: [
+    {
+      title: 'DevOps Engineer',
+      company: 'CloudTech Solutions',
+      location: 'Tel Aviv',
+      dates: '2021 - Present',
+      bullets: [
+        'Built and maintained CI/CD pipelines with Jenkins and GitHub Actions serving 40+ microservices.',
+        'Managed AWS infrastructure with Terraform: EC2, EKS, RDS, S3 and CloudFront across three environments.',
+        'Led the migration from self-managed Kubernetes to EKS, cutting cluster maintenance time by 60%.',
+        'Introduced Prometheus and Grafana dashboards that reduced mean time to detection from hours to minutes.',
+      ],
+    },
+    {
+      title: 'Junior System Administrator',
+      company: 'DataServe Ltd',
+      location: 'Herzliya',
+      dates: '2019 - 2021',
+      bullets: [
+        'Administered 120 Linux servers, automating patching and backups with Ansible and Bash.',
+        'Containerized six legacy applications with Docker, standardizing local development for three teams.',
+        'On-call incident response for production systems with 99.9% uptime SLA.',
+      ],
+    },
+  ],
+  education: [
+    {
+      degree: 'B.Sc. Computer Science',
+      institution: 'Tel Aviv University',
+      dates: '2016 - 2019',
+      details: ['Specialization in distributed systems; graduated with honors.'],
+    },
+  ],
+  projects: [
+    {
+      name: 'Internal Developer Platform',
+      dates: '2023',
+      bullets: [
+        'Designed a self-service platform on ArgoCD and Backstage that lets developers spin up preview environments in one click.',
+      ],
+    },
+  ],
+  certifications: ['AWS Certified Solutions Architect - Associate', 'CKA: Certified Kubernetes Administrator'],
+  languages: ['Hebrew (native)', 'English (fluent)'],
+  extras: [
+    {
+      label: 'Military Service',
+      items: ['IDF, Mamram - infrastructure unit. Administered mission-critical Linux systems (2013-2016).'],
+    },
+  ],
+}
+
+// Long variant: stresses pagination and the fixed sidebar band on page 2.
+const longSample: StructuredCv = {
+  ...sample,
+  experience: [
+    ...sample.experience,
+    {
+      title: 'Site Reliability Engineer (contract)',
+      company: 'FinPay',
+      location: 'Ramat Gan',
+      dates: '2018 - 2019',
+      bullets: [
+        'Hardened a payment platform for PCI-DSS compliance, closing 30+ audit findings across network and host layers.',
+        'Wrote Python tooling to reconcile infrastructure state against Terraform, catching drift in nightly runs.',
+        'Cut cloud spend 25% by right-sizing instances and moving batch workloads to spot fleets.',
+      ],
+    },
+    {
+      title: 'IT Support Specialist',
+      company: 'TechStart',
+      location: 'Tel Aviv',
+      dates: '2017 - 2018',
+      bullets: [
+        'Supported a 200-seat office: identity management, imaging, network troubleshooting.',
+        'Automated onboarding with PowerShell, cutting laptop setup from a day to under an hour.',
+      ],
+    },
+  ],
+  projects: [
+    ...sample.projects,
+    {
+      name: 'Open-source Terraform modules',
+      dates: '2022',
+      bullets: [
+        'Published reusable modules for EKS blueprints with 300+ GitHub stars; maintained through two provider major versions.',
+      ],
+    },
+  ],
+}
+
+const outDir = process.argv[2] ?? __dirname
+
+async function main() {
+  await renderToFile(<CvPdfDocument cv={sample} />, path.join(outDir, 'cv-sample-short.pdf'))
+  await renderToFile(<CvPdfDocument cv={longSample} />, path.join(outDir, 'cv-sample-long.pdf'))
+  console.log(`rendered cv-sample-short.pdf and cv-sample-long.pdf to ${outDir}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/frontend/scripts/render-design-options.tsx
+++ b/frontend/scripts/render-design-options.tsx
@@ -1,0 +1,103 @@
+/**
+ * Renders every production CV PDF template with the same sample data so the
+ * designs can be compared side by side (output: repo-root design-options/).
+ *
+ * Usage (from frontend/):
+ *   node node_modules/esbuild/bin/esbuild scripts/render-design-options.tsx \
+ *     --bundle --platform=node --format=cjs --jsx=automatic \
+ *     --outfile=scripts/.render-design-options.cjs
+ *   node scripts/.render-design-options.cjs [outputDir]
+ */
+import path from 'node:path'
+import fs from 'node:fs'
+import React from 'react'
+import { Font, renderToFile } from '@react-pdf/renderer'
+import { getTemplateComponent } from '../src/pdf/templates'
+import { CV_PDF_TEMPLATE_META } from '../src/pdf/templateMeta'
+import type { StructuredCv } from '../src/pdf/cvPdfTypes'
+
+const FONT_DIR = path.resolve(__dirname, '../node_modules/@fontsource/inter/files')
+
+Font.register({
+  family: 'Inter',
+  fonts: [
+    { src: path.join(FONT_DIR, 'inter-latin-400-normal.woff'), fontWeight: 400 },
+    { src: path.join(FONT_DIR, 'inter-latin-500-normal.woff'), fontWeight: 500 },
+    { src: path.join(FONT_DIR, 'inter-latin-600-normal.woff'), fontWeight: 600 },
+    { src: path.join(FONT_DIR, 'inter-latin-700-normal.woff'), fontWeight: 700 },
+  ],
+})
+
+const sample: StructuredCv = {
+  name: 'John Smith',
+  headline: 'DevOps Engineer',
+  contact: {
+    email: 'john.smith@email.com',
+    phone: '+972-52-123-4567',
+    location: 'Tel Aviv, Israel',
+    linkedin: 'linkedin.com/in/john-smith-devops',
+    github: 'github.com/johnsmith',
+  },
+  summary:
+    'DevOps engineer with 5 years of experience building CI/CD pipelines, automating infrastructure and improving deployment reliability across cloud environments. Passionate about developer experience and observability.',
+  skills: [
+    { category: 'Cloud & Infrastructure', items: ['AWS', 'Terraform', 'Kubernetes', 'Docker', 'Linux'] },
+    { category: 'CI/CD & Monitoring', items: ['Jenkins', 'GitHub Actions', 'ArgoCD', 'Prometheus', 'Grafana'] },
+    { items: ['Proficient in Python scripting, applied across automation and tooling tasks.'] },
+  ],
+  experience: [
+    {
+      title: 'DevOps Engineer',
+      company: 'CloudTech Solutions',
+      location: 'Tel Aviv',
+      dates: '2021 - Present',
+      bullets: [
+        'Built and maintained CI/CD pipelines with Jenkins and GitHub Actions serving 40+ microservices.',
+        'Led the migration from self-managed Kubernetes to EKS, cutting cluster maintenance time by 60%.',
+        'Introduced Prometheus and Grafana dashboards that reduced mean time to detection from hours to minutes.',
+      ],
+    },
+    {
+      title: 'Junior System Administrator',
+      company: 'DataServe Ltd',
+      location: 'Herzliya',
+      dates: '2019 - 2021',
+      bullets: [
+        'Administered 120 Linux servers, automating patching and backups with Ansible and Bash.',
+        'Containerized six legacy applications with Docker, standardizing local development for three teams.',
+      ],
+    },
+  ],
+  education: [
+    {
+      degree: 'B.Sc. Computer Science',
+      institution: 'Tel Aviv University',
+      dates: '2016 - 2019',
+      details: ['Specialization in distributed systems; graduated with honors.'],
+    },
+  ],
+  projects: [
+    {
+      name: 'Internal Developer Platform',
+      dates: '2023',
+      bullets: ['Self-service platform on ArgoCD and Backstage for one-click preview environments.'],
+    },
+  ],
+  certifications: ['AWS Certified Solutions Architect - Associate', 'CKA: Certified Kubernetes Administrator'],
+  languages: ['Hebrew (native)', 'English (fluent)'],
+  extras: [{ label: 'Military Service', items: ['IDF, Mamram - infrastructure unit (2013-2016).'] }],
+}
+
+const outDir = process.argv[2] ?? path.resolve(__dirname, '../../design-options')
+
+async function main() {
+  fs.mkdirSync(outDir, { recursive: true })
+  for (const meta of CV_PDF_TEMPLATE_META) {
+    const Component = getTemplateComponent(meta.id)
+    const file = path.join(outDir, `template-${meta.id}.pdf`)
+    await renderToFile(<Component cv={sample} />, file)
+    console.log(`rendered ${file}`)
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1) })

--- a/frontend/scripts/render-structured-cv.tsx
+++ b/frontend/scripts/render-structured-cv.tsx
@@ -1,0 +1,40 @@
+/**
+ * Renders a StructuredCv JSON file through the real PDF template - handy for
+ * debugging what a live /cv-improve/structure response will look like.
+ *
+ * Usage (from frontend/):
+ *   node node_modules/esbuild/bin/esbuild scripts/render-structured-cv.tsx \
+ *     --bundle --platform=node --format=cjs --jsx=automatic \
+ *     --outfile=scripts/.render-structured-cv.cjs
+ *   node scripts/.render-structured-cv.cjs <structured.json> <out.pdf>
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import React from 'react'
+import { Font, renderToFile } from '@react-pdf/renderer'
+import CvPdfDocument from '../src/pdf/CvPdfDocument'
+import type { StructuredCv } from '../src/pdf/cvPdfTypes'
+
+const FONT_DIR = path.resolve(__dirname, '../node_modules/@fontsource/inter/files')
+
+Font.register({
+  family: 'Inter',
+  fonts: [
+    { src: path.join(FONT_DIR, 'inter-latin-400-normal.woff'), fontWeight: 400 },
+    { src: path.join(FONT_DIR, 'inter-latin-500-normal.woff'), fontWeight: 500 },
+    { src: path.join(FONT_DIR, 'inter-latin-600-normal.woff'), fontWeight: 600 },
+    { src: path.join(FONT_DIR, 'inter-latin-700-normal.woff'), fontWeight: 700 },
+  ],
+})
+
+const [jsonPath, outPath] = process.argv.slice(2)
+if (!jsonPath || !outPath) {
+  console.error('usage: render-structured-cv <structured.json> <out.pdf>')
+  process.exit(1)
+}
+
+const cv = JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as StructuredCv
+
+renderToFile(<CvPdfDocument cv={cv} />, outPath)
+  .then(() => console.log(`rendered ${outPath}`))
+  .catch((err) => { console.error(err); process.exit(1) })

--- a/frontend/src/pages/ImproveCVScreen.css
+++ b/frontend/src/pages/ImproveCVScreen.css
@@ -754,6 +754,82 @@
 .improve-action-btn--primary:hover { box-shadow: 0 4px 14px rgba(99,102,241,0.35); }
 .improve-action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
+/* ─── Export dropdown (Styled PDF / plain text) ───────────────────── */
+.improve-export-wrap { position: relative; }
+
+.improve-export-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+}
+
+.improve-export-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 31;
+  min-width: 240px;
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-input);
+  box-shadow: 0 10px 32px rgba(30, 27, 110, 0.16);
+  padding: 0.375rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.improve-export-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.1rem;
+  padding: 0.55rem 0.75rem;
+  font-family: inherit;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: calc(var(--radius-input) - 4px);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.improve-export-option:hover { background: rgba(139, 124, 246, 0.10); }
+
+.improve-export-option-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.improve-export-option-sub {
+  font-size: 0.75rem;
+  color: var(--color-secondary);
+}
+
+.improve-export-option--current {
+  background: rgba(139, 124, 246, 0.08);
+  box-shadow: inset 2px 0 0 var(--color-accent-start);
+}
+
+.improve-export-back {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem 0.3rem;
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 0.25rem;
+  cursor: pointer;
+}
+.improve-export-back:hover { color: var(--color-primary); }
+
 .improve-result-cv {
   background: var(--color-surface);
   border: 1.5px solid var(--color-border);

--- a/frontend/src/pages/ImproveCVScreen.tsx
+++ b/frontend/src/pages/ImproveCVScreen.tsx
@@ -6,11 +6,14 @@ import {
   mergeCv,
   reanalyzeCv,
   saveImprovementSession,
+  structureCvForPdf,
   type AnalyzeResponse,
   type CvSection,
   type Proficiency,
   type SkillContext,
 } from '../services/api'
+import type { StructuredCv } from '../pdf/cvPdfTypes'
+import { CV_PDF_TEMPLATE_META, asTemplateId, type CvPdfTemplateId } from '../pdf/templateMeta'
 import AppLogo from '../components/ui/AppLogo'
 import { useError } from '../context/ErrorContext'
 import AdminNavLink from '../components/admin/AdminNavLink'
@@ -298,6 +301,12 @@ export default function ImproveCVScreen({ onClose, onReanalyze }: ImproveCVScree
   const [isReanalyzing, setIsReanalyzing] = useState(false)
   const [copied, setCopied] = useState(false)
   const [isPreparing, setIsPreparing] = useState(true)
+  const [exportMenuOpen, setExportMenuOpen] = useState(false)
+  const [exportMenuView, setExportMenuView] = useState<'main' | 'templates'>('main')
+  const [isExportingPdf, setIsExportingPdf] = useState(false)
+  // Structuring is an LLM round-trip; cache it per merged text so a second
+  // PDF export (or a retry after a download) is instant.
+  const structuredCvRef = useRef<{ text: string; structured: StructuredCv } | null>(null)
   const requestSeqRef = useRef(0)
   // Tab to open when entering the improvement phase; set by the dashboard's
   // "Improve this skill" hint, consumed once by handleContinue.
@@ -679,16 +688,48 @@ export default function ImproveCVScreen({ onClose, onReanalyze }: ImproveCVScree
     })
   }, [mergedCvText])
 
-  const handleExport = useCallback(() => {
-    const filename = (sessionStorage.getItem(CV_FILENAME_KEY) ?? 'cv').replace(/\.pdf$/i, '')
-    const blob = new Blob([mergedCvText], { type: 'text/plain;charset=utf-8' })
+  const exportFilenameBase = () =>
+    (sessionStorage.getItem(CV_FILENAME_KEY) ?? 'cv').replace(/\.pdf$/i, '')
+
+  const downloadBlob = (blob: Blob, filename: string) => {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `${filename}_improved.txt`
+    a.download = filename
     a.click()
     URL.revokeObjectURL(url)
+  }
+
+  const handleExportTxt = useCallback(() => {
+    setExportMenuOpen(false)
+    const blob = new Blob([mergedCvText], { type: 'text/plain;charset=utf-8' })
+    downloadBlob(blob, `${exportFilenameBase()}_improved.txt`)
   }, [mergedCvText])
+
+  const handleExportPdf = useCallback(async (templateId: CvPdfTemplateId) => {
+    setExportMenuOpen(false)
+    setExportMenuView('main')
+    setIsExportingPdf(true)
+    // Remember the choice so the picker opens on the user's usual design.
+    localStorage.setItem('cvPdfTemplateId', templateId)
+    try {
+      let structured = structuredCvRef.current?.text === mergedCvText
+        ? structuredCvRef.current.structured
+        : null
+      if (!structured) {
+        structured = await structureCvForPdf(mergedCvText, jobTitle)
+        structuredCvRef.current = { text: mergedCvText, structured }
+      }
+      // Heavy renderer + fonts: loaded on demand, only when a PDF is exported.
+      const { generateCvPdfBlob } = await import('../pdf/generateCvPdf')
+      const blob = await generateCvPdfBlob(structured, templateId)
+      downloadBlob(blob, `${exportFilenameBase()}_improved.pdf`)
+    } catch (err) {
+      reportError(err instanceof Error ? err : new Error('PDF export failed. Please try again.'))
+    } finally {
+      setIsExportingPdf(false)
+    }
+  }, [mergedCvText, jobTitle, reportError])
 
   const handleReanalyze = useCallback(async () => {
     if (!jobTitle) { reportError(new Error('No role found - please analyze a CV first.')); return }
@@ -1115,10 +1156,66 @@ export default function ImproveCVScreen({ onClose, onReanalyze }: ImproveCVScree
                 : <><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy</>
               }
             </button>
-            <button className="improve-action-btn" onClick={handleExport}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-              Export
-            </button>
+            <div className="improve-export-wrap">
+              <button
+                className="improve-action-btn"
+                onClick={() => { setExportMenuOpen((open) => !open); setExportMenuView('main') }}
+                disabled={isExportingPdf}
+                aria-haspopup="menu"
+                aria-expanded={exportMenuOpen}
+              >
+                {isExportingPdf
+                  ? <><div className="improve-spinner improve-spinner--sm" /> Designing PDF…</>
+                  : <>
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                      Export
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                    </>
+                }
+              </button>
+              {exportMenuOpen && (
+                <>
+                  <div className="improve-export-backdrop" onClick={() => { setExportMenuOpen(false); setExportMenuView('main') }} />
+                  <div className="improve-export-menu" role="menu">
+                    {exportMenuView === 'main' ? (
+                      <>
+                        <button className="improve-export-option" role="menuitem" onClick={() => setExportMenuView('templates')}>
+                          <span className="improve-export-option-title">Styled PDF
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ marginLeft: 6 }}><polyline points="9 18 15 12 9 6"/></svg>
+                          </span>
+                          <span className="improve-export-option-sub">Choose one of {CV_PDF_TEMPLATE_META.length} designs</span>
+                        </button>
+                        <button className="improve-export-option" role="menuitem" onClick={handleExportTxt}>
+                          <span className="improve-export-option-title">Plain text (.txt)</span>
+                          <span className="improve-export-option-sub">Raw text for further editing</span>
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button className="improve-export-back" onClick={() => setExportMenuView('main')}>
+                          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+                          Choose a design
+                        </button>
+                        {CV_PDF_TEMPLATE_META.map((template) => {
+                          const isDefault = asTemplateId(localStorage.getItem('cvPdfTemplateId')) === template.id
+                          return (
+                            <button
+                              key={template.id}
+                              className={`improve-export-option${isDefault ? ' improve-export-option--current' : ''}`}
+                              role="menuitem"
+                              onClick={() => void handleExportPdf(template.id)}
+                            >
+                              <span className="improve-export-option-title">{template.name}</span>
+                              <span className="improve-export-option-sub">{template.description}</span>
+                            </button>
+                          )
+                        })}
+                      </>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
             <button className="improve-action-btn improve-action-btn--primary" onClick={handleReanalyze} disabled={isReanalyzing}>
               {isReanalyzing
                 ? <><div className="improve-spinner improve-spinner--sm" /> Scoring…</>

--- a/frontend/src/pdf/CvPdfDocument.tsx
+++ b/frontend/src/pdf/CvPdfDocument.tsx
@@ -1,0 +1,536 @@
+/**
+ * The designed CV PDF template: a full-height deep-indigo sidebar (contact,
+ * skills, languages, certifications) beside a light main column (summary,
+ * experience, projects, education, extras), in the CareerLens brand palette.
+ *
+ * Pure component: fonts must be registered by the caller (registerPdfFonts in
+ * the browser, file-path registration in the node smoke script).
+ */
+import { Document, Font, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
+import type {
+  StructuredCv,
+  StructuredCvEducation,
+  StructuredCvExperience,
+  StructuredCvProject,
+} from './cvPdfTypes'
+
+// Default hyphenation inserts breaks mid-word ("Kuber-netes"). Disable it, but
+// still chunk very long unbroken tokens (URLs) so they wrap instead of
+// overflowing the column.
+Font.registerHyphenationCallback((word) => {
+  if (word.length <= 16) return [word]
+  const chunks: string[] = []
+  for (let i = 0; i < word.length; i += 12) chunks.push(word.slice(i, i + 12))
+  return chunks
+})
+
+const SIDEBAR_WIDTH = 186
+
+const INDIGO = '#1e1b6e'
+const INK = '#17153a'
+const BODY = '#3d3a5c'
+const MUTED = '#6d66ab'
+const ACCENT = '#8b7cf6'
+const ACCENT_DEEP = '#6c5fd8'
+const SIDEBAR_HEADING = '#beb3fa'
+const SIDEBAR_TEXT = 'rgba(255, 255, 255, 0.92)'
+const SIDEBAR_FAINT = 'rgba(255, 255, 255, 0.55)'
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: 'Inter',
+    flexDirection: 'row',
+    paddingTop: 0,
+    paddingBottom: 30,
+    backgroundColor: '#ffffff',
+  },
+  sidebarBg: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: SIDEBAR_WIDTH,
+    backgroundColor: INDIGO,
+  },
+  sidebarEdge: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: SIDEBAR_WIDTH,
+    width: 2.5,
+    backgroundColor: ACCENT,
+  },
+
+  // ── Sidebar ────────────────────────────────────────────────────────
+  sidebar: {
+    width: SIDEBAR_WIDTH,
+    paddingTop: 36,
+    paddingBottom: 10,
+    paddingLeft: 22,
+    paddingRight: 18,
+  },
+  monogram: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: ACCENT,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 22,
+  },
+  monogramText: {
+    fontSize: 17,
+    fontWeight: 700,
+    color: '#ffffff',
+    letterSpacing: 0.5,
+  },
+  sidebarSection: { marginBottom: 18 },
+  sidebarHeading: {
+    fontSize: 8,
+    fontWeight: 700,
+    letterSpacing: 1.8,
+    textTransform: 'uppercase',
+    color: SIDEBAR_HEADING,
+    paddingBottom: 5,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(255, 255, 255, 0.18)',
+    marginBottom: 9,
+  },
+  contactItem: { marginBottom: 7 },
+  contactLabel: {
+    fontSize: 6.4,
+    fontWeight: 600,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    color: SIDEBAR_FAINT,
+    marginBottom: 1.5,
+  },
+  contactValue: {
+    fontSize: 8.2,
+    lineHeight: 1.35,
+    color: SIDEBAR_TEXT,
+  },
+  skillGroup: { marginBottom: 8 },
+  skillCategory: {
+    fontSize: 7.5,
+    fontWeight: 600,
+    color: '#cfc7ff',
+    marginBottom: 5,
+  },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap' },
+  chip: {
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.32)',
+    borderRadius: 8,
+    paddingVertical: 2.5,
+    paddingHorizontal: 7,
+    marginRight: 4,
+    marginBottom: 4,
+  },
+  chipText: { fontSize: 7.8, color: '#ffffff' },
+  sidebarListItem: { flexDirection: 'row', marginBottom: 4.5 },
+  sidebarListDot: {
+    width: 3,
+    height: 3,
+    borderRadius: 1.5,
+    backgroundColor: ACCENT,
+    marginTop: 3.8,
+    marginRight: 6,
+  },
+  sidebarListText: {
+    flex: 1,
+    fontSize: 8.2,
+    lineHeight: 1.4,
+    color: SIDEBAR_TEXT,
+  },
+
+  // ── Main column ────────────────────────────────────────────────────
+  main: {
+    flex: 1,
+    paddingTop: 38,
+    paddingLeft: 28,
+    paddingRight: 30,
+  },
+  name: {
+    fontSize: 24,
+    fontWeight: 700,
+    lineHeight: 1.12,
+    letterSpacing: -0.4,
+    color: INK,
+  },
+  headline: {
+    fontSize: 10,
+    fontWeight: 600,
+    letterSpacing: 2.4,
+    textTransform: 'uppercase',
+    color: ACCENT,
+    marginTop: 5,
+  },
+  accentBar: {
+    width: 44,
+    height: 3,
+    borderRadius: 1.5,
+    backgroundColor: ACCENT,
+    marginTop: 12,
+  },
+  section: { marginTop: 16 },
+  sectionHeadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  sectionHeading: {
+    fontSize: 9,
+    fontWeight: 700,
+    letterSpacing: 1.7,
+    textTransform: 'uppercase',
+    color: INDIGO,
+  },
+  sectionRule: {
+    flex: 1,
+    height: 1,
+    backgroundColor: 'rgba(30, 27, 110, 0.14)',
+    marginLeft: 8,
+  },
+  paragraph: {
+    fontSize: 9.3,
+    lineHeight: 1.55,
+    color: BODY,
+  },
+  entry: { marginBottom: 11 },
+  entryHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  entryHeaderLeft: { flex: 1, paddingRight: 8 },
+  entryTitle: {
+    fontSize: 10.3,
+    fontWeight: 600,
+    color: INK,
+  },
+  entrySub: {
+    fontSize: 8.6,
+    fontWeight: 500,
+    color: MUTED,
+    marginTop: 1.5,
+  },
+  datePill: {
+    backgroundColor: '#f0edfd',
+    borderRadius: 8,
+    paddingVertical: 2,
+    paddingHorizontal: 7,
+    marginTop: 1,
+  },
+  datePillText: {
+    fontSize: 8,
+    fontWeight: 600,
+    color: ACCENT_DEEP,
+  },
+  bulletRow: { flexDirection: 'row', marginTop: 3.5 },
+  bulletDot: {
+    width: 3,
+    height: 3,
+    borderRadius: 1.5,
+    backgroundColor: ACCENT,
+    marginTop: 4.2,
+    marginRight: 6,
+  },
+  bulletText: {
+    flex: 1,
+    fontSize: 9.1,
+    lineHeight: 1.45,
+    color: BODY,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 12,
+    left: SIDEBAR_WIDTH + 20,
+    right: 30,
+    textAlign: 'right',
+    fontSize: 7.5,
+    color: '#9b8ec4',
+  },
+})
+
+function initials(name: string): string {
+  const parts = name.split(/\s+/).filter(Boolean)
+  const first = parts[0]?.[0] ?? ''
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : ''
+  return (first + last).toUpperCase() || 'CV'
+}
+
+/** Show URLs as clean handles: no protocol, no www, no trailing slash. */
+function cleanUrl(value: string): string {
+  return value.replace(/^https?:\/\//i, '').replace(/^www\./i, '').replace(/\/$/, '')
+}
+
+/** A skills item that reads like prose rather than a skill name. */
+function isSentenceLike(item: string): boolean {
+  return item.length > 40 || item.trim().split(/\s+/).length > 5 || /[.!?]$/.test(item.trim())
+}
+
+function SectionHeading({ title }: { title: string }) {
+  return (
+    <View style={styles.sectionHeadingRow}>
+      <Text style={styles.sectionHeading}>{title}</Text>
+      <View style={styles.sectionRule} />
+    </View>
+  )
+}
+
+/**
+ * Groups a section heading with the first block of its content so a heading is
+ * never orphaned at a page bottom, then lets the remaining blocks flow, each
+ * one unbreakable. (minPresenceAhead proved a no-op in this layout - verified
+ * against rendered output - so keep-together grouping is done with wrap={false}.)
+ */
+function EntrySection({ title, blocks }: { title: string; blocks: JSX.Element[] }) {
+  if (blocks.length === 0) return null
+  return (
+    <View style={styles.section}>
+      <View wrap={false}>
+        <SectionHeading title={title} />
+        {blocks[0]}
+      </View>
+      {blocks.slice(1).map((block, i) => (
+        <View key={i} wrap={false}>
+          {block}
+        </View>
+      ))}
+    </View>
+  )
+}
+
+function Bullet({ text }: { text: string }) {
+  return (
+    <View style={styles.bulletRow}>
+      <View style={styles.bulletDot} />
+      <Text style={styles.bulletText}>{text}</Text>
+    </View>
+  )
+}
+
+function ExperienceEntry({ entry }: { entry: StructuredCvExperience }) {
+  const sub = [entry.company, entry.location].filter(Boolean).join('  ·  ')
+  return (
+    <View style={styles.entry}>
+      <View style={styles.entryHeader}>
+        <View style={styles.entryHeaderLeft}>
+          <Text style={styles.entryTitle}>{entry.title}</Text>
+          {sub ? <Text style={styles.entrySub}>{sub}</Text> : null}
+        </View>
+        {entry.dates ? (
+          <View style={styles.datePill}>
+            <Text style={styles.datePillText}>{entry.dates}</Text>
+          </View>
+        ) : null}
+      </View>
+      {entry.bullets.map((bullet, i) => (
+        <Bullet key={i} text={bullet} />
+      ))}
+    </View>
+  )
+}
+
+function ProjectEntry({ entry }: { entry: StructuredCvProject }) {
+  return (
+    <View style={styles.entry}>
+      <View style={styles.entryHeader}>
+        <View style={styles.entryHeaderLeft}>
+          <Text style={styles.entryTitle}>{entry.name}</Text>
+        </View>
+        {entry.dates ? (
+          <View style={styles.datePill}>
+            <Text style={styles.datePillText}>{entry.dates}</Text>
+          </View>
+        ) : null}
+      </View>
+      {entry.bullets.map((bullet, i) => (
+        <Bullet key={i} text={bullet} />
+      ))}
+    </View>
+  )
+}
+
+function EducationEntry({ entry }: { entry: StructuredCvEducation }) {
+  return (
+    <View style={styles.entry}>
+      <View style={styles.entryHeader}>
+        <View style={styles.entryHeaderLeft}>
+          <Text style={styles.entryTitle}>{entry.degree}</Text>
+          {entry.institution ? <Text style={styles.entrySub}>{entry.institution}</Text> : null}
+        </View>
+        {entry.dates ? (
+          <View style={styles.datePill}>
+            <Text style={styles.datePillText}>{entry.dates}</Text>
+          </View>
+        ) : null}
+      </View>
+      {entry.details.map((detail, i) => (
+        <Bullet key={i} text={detail} />
+      ))}
+    </View>
+  )
+}
+
+interface ContactRow {
+  label: string
+  value: string
+}
+
+function contactRows(cv: StructuredCv): ContactRow[] {
+  const { contact } = cv
+  const rows: ContactRow[] = []
+  if (contact.email) rows.push({ label: 'Email', value: contact.email })
+  if (contact.phone) rows.push({ label: 'Phone', value: contact.phone })
+  if (contact.location) rows.push({ label: 'Location', value: contact.location })
+  if (contact.linkedin) rows.push({ label: 'LinkedIn', value: cleanUrl(contact.linkedin) })
+  if (contact.github) rows.push({ label: 'GitHub', value: cleanUrl(contact.github) })
+  if (contact.website) rows.push({ label: 'Website', value: cleanUrl(contact.website) })
+  return rows
+}
+
+export default function CvPdfDocument({ cv }: { cv: StructuredCv }) {
+  const contacts = contactRows(cv)
+
+  return (
+    <Document title={`${cv.name} - CV`} author={cv.name} creator="CareerLens">
+      <Page size="A4" style={styles.page}>
+        {/* Full-height brand band behind the sidebar, repeated on every page */}
+        <View style={styles.sidebarBg} fixed />
+        <View style={styles.sidebarEdge} fixed />
+
+        <View style={styles.sidebar}>
+          <View style={styles.monogram}>
+            <Text style={styles.monogramText}>{initials(cv.name)}</Text>
+          </View>
+
+          {contacts.length > 0 && (
+            <View style={styles.sidebarSection}>
+              <Text style={styles.sidebarHeading}>Contact</Text>
+              {contacts.map((row) => (
+                <View key={row.label} style={styles.contactItem}>
+                  <Text style={styles.contactLabel}>{row.label}</Text>
+                  <Text style={styles.contactValue}>{row.value}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+
+          {cv.skills.length > 0 && (
+            <View style={styles.sidebarSection}>
+              <Text style={styles.sidebarHeading}>Skills</Text>
+              {cv.skills.map((group, i) => {
+                // The improve flow appends full sentences ("Basic familiarity
+                // with React in collaborative settings.") to the skills
+                // section. Sentence-length items render as list rows - as
+                // chips they balloon and bury the very additions the user
+                // just made.
+                const chips = group.items.filter((item) => !isSentenceLike(item))
+                const sentences = group.items.filter(isSentenceLike)
+                return (
+                  <View key={i} style={styles.skillGroup}>
+                    {group.category ? <Text style={styles.skillCategory}>{group.category}</Text> : null}
+                    {chips.length > 0 && (
+                      <View style={styles.chipRow}>
+                        {chips.map((skill, j) => (
+                          <View key={j} style={styles.chip}>
+                            <Text style={styles.chipText}>{skill}</Text>
+                          </View>
+                        ))}
+                      </View>
+                    )}
+                    {sentences.map((sentence, j) => (
+                      <View key={`s${j}`} style={styles.sidebarListItem}>
+                        <View style={styles.sidebarListDot} />
+                        <Text style={styles.sidebarListText}>{sentence}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )
+              })}
+            </View>
+          )}
+
+          {cv.languages.length > 0 && (
+            <View style={styles.sidebarSection}>
+              <Text style={styles.sidebarHeading}>Languages</Text>
+              {cv.languages.map((language, i) => (
+                <View key={i} style={styles.sidebarListItem}>
+                  <View style={styles.sidebarListDot} />
+                  <Text style={styles.sidebarListText}>{language}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+
+          {cv.certifications.length > 0 && (
+            <View style={styles.sidebarSection}>
+              <Text style={styles.sidebarHeading}>Certifications</Text>
+              {cv.certifications.map((certification, i) => (
+                <View key={i} style={styles.sidebarListItem}>
+                  <View style={styles.sidebarListDot} />
+                  <Text style={styles.sidebarListText}>{certification}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+
+        <View style={styles.main}>
+          <Text style={styles.name}>{cv.name}</Text>
+          {cv.headline ? <Text style={styles.headline}>{cv.headline}</Text> : null}
+          <View style={styles.accentBar} />
+
+          {cv.summary ? (
+            <View style={styles.section} wrap={false}>
+              <SectionHeading title="Profile" />
+              <Text style={styles.paragraph}>{cv.summary}</Text>
+            </View>
+          ) : null}
+
+          <EntrySection
+            title="Experience"
+            blocks={cv.experience.map((entry, i) => (
+              <ExperienceEntry key={i} entry={entry} />
+            ))}
+          />
+
+          <EntrySection
+            title="Projects"
+            blocks={cv.projects.map((entry, i) => (
+              <ProjectEntry key={i} entry={entry} />
+            ))}
+          />
+
+          <EntrySection
+            title="Education"
+            blocks={cv.education.map((entry, i) => (
+              <EducationEntry key={i} entry={entry} />
+            ))}
+          />
+
+          {cv.extras.map((extra, i) => (
+            <EntrySection
+              key={i}
+              title={extra.label}
+              blocks={extra.items.map((item, j) => (
+                <Bullet key={j} text={item} />
+              ))}
+            />
+          ))}
+        </View>
+
+        <Text
+          style={styles.footer}
+          fixed
+          render={({ pageNumber, totalPages }) =>
+            totalPages > 1 ? `${cv.name}  ·  ${pageNumber} / ${totalPages}` : ''
+          }
+        />
+      </Page>
+    </Document>
+  )
+}

--- a/frontend/src/pdf/cvPdfTypes.ts
+++ b/frontend/src/pdf/cvPdfTypes.ts
@@ -1,0 +1,58 @@
+/**
+ * The typed layout contract between the backend structuring agent and the PDF
+ * template. Keep in sync with backend/src/agents/cvStructure.agent.ts.
+ */
+
+export interface StructuredCvContact {
+  email?: string
+  phone?: string
+  location?: string
+  linkedin?: string
+  github?: string
+  website?: string
+}
+
+export interface StructuredCvExperience {
+  title: string
+  company?: string
+  location?: string
+  dates?: string
+  bullets: string[]
+}
+
+export interface StructuredCvEducation {
+  degree: string
+  institution?: string
+  dates?: string
+  details: string[]
+}
+
+export interface StructuredCvProject {
+  name: string
+  dates?: string
+  bullets: string[]
+}
+
+export interface StructuredCvSkillGroup {
+  category?: string
+  items: string[]
+}
+
+export interface StructuredCvExtraSection {
+  label: string
+  items: string[]
+}
+
+export interface StructuredCv {
+  name: string
+  headline?: string
+  contact: StructuredCvContact
+  summary?: string
+  skills: StructuredCvSkillGroup[]
+  experience: StructuredCvExperience[]
+  education: StructuredCvEducation[]
+  projects: StructuredCvProject[]
+  certifications: string[]
+  languages: string[]
+  extras: StructuredCvExtraSection[]
+}

--- a/frontend/src/pdf/generateCvPdf.ts
+++ b/frontend/src/pdf/generateCvPdf.ts
@@ -1,0 +1,20 @@
+/**
+ * Renders the structured CV into a PDF blob with the chosen template. Kept in
+ * its own module so the screen can `import()` it on demand - @react-pdf/renderer
+ * is heavy and only needed when the user actually exports a PDF.
+ */
+import { createElement } from 'react'
+import { pdf, type DocumentProps } from '@react-pdf/renderer'
+import type { ReactElement } from 'react'
+import { registerPdfFonts } from './registerPdfFonts'
+import { getTemplateComponent } from './templates'
+import type { CvPdfTemplateId } from './templateMeta'
+import type { StructuredCv } from './cvPdfTypes'
+
+export async function generateCvPdfBlob(cv: StructuredCv, templateId?: CvPdfTemplateId): Promise<Blob> {
+  registerPdfFonts()
+  // pdf() wants ReactElement<DocumentProps>; our wrappers' own prop is `cv`,
+  // but the element each one renders is a <Document>, so the cast is sound.
+  const element = createElement(getTemplateComponent(templateId), { cv }) as unknown as ReactElement<DocumentProps>
+  return pdf(element).toBlob()
+}

--- a/frontend/src/pdf/registerPdfFonts.ts
+++ b/frontend/src/pdf/registerPdfFonts.ts
@@ -1,0 +1,26 @@
+/**
+ * Registers the Inter faces the CV PDF template uses. Browser-only: relies on
+ * Vite's `?url` asset imports. The node smoke test registers the same faces
+ * from file paths instead (scripts/render-cv-pdf-sample.mjs).
+ */
+import { Font } from '@react-pdf/renderer'
+import inter400 from '@fontsource/inter/files/inter-latin-400-normal.woff?url'
+import inter500 from '@fontsource/inter/files/inter-latin-500-normal.woff?url'
+import inter600 from '@fontsource/inter/files/inter-latin-600-normal.woff?url'
+import inter700 from '@fontsource/inter/files/inter-latin-700-normal.woff?url'
+
+let registered = false
+
+export function registerPdfFonts(): void {
+  if (registered) return
+  registered = true
+  Font.register({
+    family: 'Inter',
+    fonts: [
+      { src: inter400, fontWeight: 400 },
+      { src: inter500, fontWeight: 500 },
+      { src: inter600, fontWeight: 600 },
+      { src: inter700, fontWeight: 700 },
+    ],
+  })
+}

--- a/frontend/src/pdf/shared.ts
+++ b/frontend/src/pdf/shared.ts
@@ -1,0 +1,54 @@
+/**
+ * Palette and helpers shared by all CV PDF templates.
+ */
+import { Font } from '@react-pdf/renderer'
+import type { StructuredCv } from './cvPdfTypes'
+
+export const INK = '#17153a'
+export const BODY = '#3d3a5c'
+export const MUTED = '#6d66ab'
+export const INDIGO = '#1e1b6e'
+export const ACCENT = '#8b7cf6'
+export const ACCENT_DEEP = '#6c5fd8'
+export const ACCENT_LIGHT = '#f0edfd'
+
+let hyphenationConfigured = false
+
+/**
+ * Default hyphenation inserts breaks mid-word ("Kuber-netes"). Disable it, but
+ * still chunk very long unbroken tokens (URLs) so they wrap instead of
+ * overflowing their column. Every template calls this before rendering.
+ */
+export function configurePdfHyphenation(): void {
+  if (hyphenationConfigured) return
+  hyphenationConfigured = true
+  Font.registerHyphenationCallback((word) => {
+    if (word.length <= 16) return [word]
+    const chunks: string[] = []
+    for (let i = 0; i < word.length; i += 12) chunks.push(word.slice(i, i + 12))
+    return chunks
+  })
+}
+
+/** Show URLs as clean handles: no protocol, no www, no trailing slash. */
+export function cleanUrl(value: string): string {
+  return value.replace(/^https?:\/\//i, '').replace(/^www\./i, '').replace(/\/$/, '')
+}
+
+/** A skills item that reads like prose rather than a skill name. */
+export function isSentenceLike(item: string): boolean {
+  return item.length > 40 || item.trim().split(/\s+/).length > 5 || /[.!?]$/.test(item.trim())
+}
+
+/** All present contact values, URLs cleaned, in display order. */
+export function contactValues(cv: StructuredCv): string[] {
+  const c = cv.contact
+  return [
+    c.email,
+    c.phone,
+    c.location,
+    c.linkedin && cleanUrl(c.linkedin),
+    c.github && cleanUrl(c.github),
+    c.website && cleanUrl(c.website),
+  ].filter(Boolean) as string[]
+}

--- a/frontend/src/pdf/templateMeta.ts
+++ b/frontend/src/pdf/templateMeta.ts
@@ -1,0 +1,25 @@
+/**
+ * Template metadata only - safe to import from UI code. The template
+ * components themselves live behind the lazy generateCvPdf chunk (they pull
+ * in @react-pdf/renderer, which must stay out of the main bundle).
+ */
+export type CvPdfTemplateId = 'sidebar' | 'headerBand' | 'minimal' | 'timeline'
+
+export interface CvPdfTemplateMeta {
+  id: CvPdfTemplateId
+  name: string
+  description: string
+}
+
+export const CV_PDF_TEMPLATE_META: CvPdfTemplateMeta[] = [
+  { id: 'sidebar', name: 'Classic Sidebar', description: 'Deep indigo sidebar with skill chips' },
+  { id: 'headerBand', name: 'Header Band', description: 'Bold header band, light skills rail' },
+  { id: 'minimal', name: 'Minimal', description: 'Clean single column, lots of air' },
+  { id: 'timeline', name: 'Timeline', description: 'Career story on a vertical timeline' },
+]
+
+export const DEFAULT_TEMPLATE_ID: CvPdfTemplateId = 'sidebar'
+
+export function asTemplateId(value: string | null | undefined): CvPdfTemplateId {
+  return CV_PDF_TEMPLATE_META.some((t) => t.id === value) ? (value as CvPdfTemplateId) : DEFAULT_TEMPLATE_ID
+}

--- a/frontend/src/pdf/templates/headerBand.tsx
+++ b/frontend/src/pdf/templates/headerBand.tsx
@@ -1,0 +1,209 @@
+/**
+ * "Header Band" template: full-width deep-indigo header with name and contact,
+ * main column beside a light lavender rail (skills, education, certifications).
+ */
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
+import type { StructuredCv, StructuredCvExperience } from '../cvPdfTypes'
+import { ACCENT, ACCENT_DEEP, ACCENT_LIGHT, BODY, INDIGO, INK, MUTED, configurePdfHyphenation, contactValues, isSentenceLike } from '../shared'
+
+const styles = StyleSheet.create({
+  page: { fontFamily: 'Inter', paddingBottom: 40, backgroundColor: '#ffffff' },
+  band: { backgroundColor: INDIGO, paddingTop: 34, paddingBottom: 26, paddingHorizontal: 44 },
+  bandName: { fontSize: 26, fontWeight: 700, letterSpacing: -0.4, color: '#ffffff' },
+  bandHeadline: { fontSize: 10, fontWeight: 600, letterSpacing: 2.6, textTransform: 'uppercase', color: '#beb3fa', marginTop: 5 },
+  bandContact: { flexDirection: 'row', flexWrap: 'wrap', marginTop: 12 },
+  bandContactItem: { fontSize: 8.2, color: 'rgba(255,255,255,0.85)', marginRight: 14, marginBottom: 2 },
+  bandAccent: { height: 3.5, backgroundColor: ACCENT },
+  body: { flexDirection: 'row', paddingTop: 24, paddingHorizontal: 44 },
+  main: { flex: 1, paddingRight: 24 },
+  rail: { width: 168, backgroundColor: '#f6f4fe', borderRadius: 8, padding: 14, alignSelf: 'flex-start' },
+  sectionHeading: { fontSize: 8.5, fontWeight: 700, letterSpacing: 2, textTransform: 'uppercase', color: INDIGO, marginBottom: 8 },
+  section: { marginBottom: 18 },
+  paragraph: { fontSize: 9.3, lineHeight: 1.55, color: BODY },
+  entry: { marginBottom: 11 },
+  entryRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' },
+  entryTitle: { fontSize: 10.4, fontWeight: 600, color: INK },
+  entrySub: { fontSize: 8.7, fontWeight: 500, color: MUTED, marginTop: 1.5 },
+  datePill: { backgroundColor: ACCENT_LIGHT, borderRadius: 8, paddingVertical: 2, paddingHorizontal: 7, marginTop: 1 },
+  datePillText: { fontSize: 8, fontWeight: 600, color: ACCENT_DEEP },
+  bullet: { flexDirection: 'row', marginTop: 3.5 },
+  dot: { width: 3, height: 3, borderRadius: 1.5, backgroundColor: ACCENT, marginTop: 4.2, marginRight: 6 },
+  bulletText: { flex: 1, fontSize: 9.1, lineHeight: 1.45, color: BODY },
+  railHeading: { fontSize: 8, fontWeight: 700, letterSpacing: 1.8, textTransform: 'uppercase', color: INDIGO, marginBottom: 7 },
+  railSection: { marginBottom: 14 },
+  railCat: { fontSize: 7.6, fontWeight: 600, color: ACCENT_DEEP, marginBottom: 4 },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap' },
+  chip: { backgroundColor: '#ffffff', borderWidth: 1, borderColor: 'rgba(108, 95, 216, 0.35)', borderRadius: 7, paddingVertical: 2.2, paddingHorizontal: 6, marginRight: 4, marginBottom: 4 },
+  chipText: { fontSize: 7.6, color: INK },
+  railText: { fontSize: 8.2, lineHeight: 1.45, color: BODY, marginBottom: 4 },
+  railItemRow: { flexDirection: 'row', marginBottom: 4 },
+  footer: { position: 'absolute', bottom: 12, left: 44, right: 44, textAlign: 'right', fontSize: 7.5, color: '#9b8ec4' },
+})
+
+function Bullet({ text }: { text: string }) {
+  return (
+    <View style={styles.bullet}>
+      <View style={styles.dot} />
+      <Text style={styles.bulletText}>{text}</Text>
+    </View>
+  )
+}
+
+function Entry({ title, sub, dates, bullets }: { title: string; sub?: string; dates?: string; bullets: string[] }) {
+  return (
+    <View style={styles.entry}>
+      <View style={styles.entryRow}>
+        <View style={{ flex: 1, paddingRight: 8 }}>
+          <Text style={styles.entryTitle}>{title}</Text>
+          {sub ? <Text style={styles.entrySub}>{sub}</Text> : null}
+        </View>
+        {dates ? (
+          <View style={styles.datePill}>
+            <Text style={styles.datePillText}>{dates}</Text>
+          </View>
+        ) : null}
+      </View>
+      {bullets.map((b, i) => (
+        <Bullet key={i} text={b} />
+      ))}
+    </View>
+  )
+}
+
+function expSub(e: StructuredCvExperience): string {
+  return [e.company, e.location].filter(Boolean).join('  ·  ')
+}
+
+function MainSection({ title, blocks }: { title: string; blocks: JSX.Element[] }) {
+  if (blocks.length === 0) return null
+  return (
+    <View style={styles.section}>
+      <View wrap={false}>
+        <Text style={styles.sectionHeading}>{title}</Text>
+        {blocks[0]}
+      </View>
+      {blocks.slice(1).map((block, i) => (
+        <View key={i} wrap={false}>{block}</View>
+      ))}
+    </View>
+  )
+}
+
+export default function HeaderBandCvPdf({ cv }: { cv: StructuredCv }) {
+  configurePdfHyphenation()
+  return (
+    <Document title={`${cv.name} - CV`} author={cv.name} creator="CareerLens">
+      <Page size="A4" style={styles.page}>
+        <View style={styles.band}>
+          <Text style={styles.bandName}>{cv.name}</Text>
+          {cv.headline ? <Text style={styles.bandHeadline}>{cv.headline}</Text> : null}
+          <View style={styles.bandContact}>
+            {contactValues(cv).map((item, i) => (
+              <Text key={i} style={styles.bandContactItem}>{item}</Text>
+            ))}
+          </View>
+        </View>
+        <View style={styles.bandAccent} />
+
+        <View style={styles.body}>
+          <View style={styles.main}>
+            {cv.summary ? (
+              <View style={styles.section} wrap={false}>
+                <Text style={styles.sectionHeading}>Profile</Text>
+                <Text style={styles.paragraph}>{cv.summary}</Text>
+              </View>
+            ) : null}
+
+            <MainSection
+              title="Experience"
+              blocks={cv.experience.map((e, i) => (
+                <Entry key={i} title={e.title} sub={expSub(e)} dates={e.dates} bullets={e.bullets} />
+              ))}
+            />
+
+            <MainSection
+              title="Projects"
+              blocks={cv.projects.map((p, i) => (
+                <Entry key={i} title={p.name} dates={p.dates} bullets={p.bullets} />
+              ))}
+            />
+
+            {cv.extras.map((x, i) => (
+              <View key={i} style={styles.section} wrap={false}>
+                <Text style={styles.sectionHeading}>{x.label}</Text>
+                {x.items.map((item, j) => (
+                  <Bullet key={j} text={item} />
+                ))}
+              </View>
+            ))}
+          </View>
+
+          <View style={styles.rail}>
+            {cv.skills.length > 0 && (
+              <View style={styles.railSection}>
+                <Text style={styles.railHeading}>Skills</Text>
+                {cv.skills.map((g, i) => (
+                  <View key={i} style={{ marginBottom: 6 }}>
+                    {g.category ? <Text style={styles.railCat}>{g.category}</Text> : null}
+                    <View style={styles.chipRow}>
+                      {g.items.filter((s) => !isSentenceLike(s)).map((s, j) => (
+                        <View key={j} style={styles.chip}>
+                          <Text style={styles.chipText}>{s}</Text>
+                        </View>
+                      ))}
+                    </View>
+                    {g.items.filter(isSentenceLike).map((s, j) => (
+                      <View key={`s${j}`} style={styles.railItemRow}>
+                        <View style={styles.dot} />
+                        <Text style={[styles.railText, { flex: 1, marginBottom: 0 }]}>{s}</Text>
+                      </View>
+                    ))}
+                  </View>
+                ))}
+              </View>
+            )}
+
+            {cv.education.length > 0 && (
+              <View style={styles.railSection}>
+                <Text style={styles.railHeading}>Education</Text>
+                {cv.education.map((e, i) => (
+                  <View key={i} style={{ marginBottom: 6 }}>
+                    <Text style={[styles.railText, { fontWeight: 600, color: INK, marginBottom: 1 }]}>{e.degree}</Text>
+                    <Text style={styles.railText}>{[e.institution, e.dates].filter(Boolean).join(' · ')}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+
+            {cv.certifications.length > 0 && (
+              <View style={styles.railSection}>
+                <Text style={styles.railHeading}>Certifications</Text>
+                {cv.certifications.map((c, i) => (
+                  <View key={i} style={styles.railItemRow}>
+                    <View style={styles.dot} />
+                    <Text style={[styles.railText, { flex: 1, marginBottom: 0 }]}>{c}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+
+            {cv.languages.length > 0 && (
+              <View style={styles.railSection}>
+                <Text style={styles.railHeading}>Languages</Text>
+                {cv.languages.map((l, i) => (
+                  <Text key={i} style={styles.railText}>{l}</Text>
+                ))}
+              </View>
+            )}
+          </View>
+        </View>
+
+        <Text
+          style={styles.footer}
+          fixed
+          render={({ pageNumber, totalPages }) => (totalPages > 1 ? `${cv.name}  ·  ${pageNumber} / ${totalPages}` : '')}
+        />
+      </Page>
+    </Document>
+  )
+}

--- a/frontend/src/pdf/templates/index.ts
+++ b/frontend/src/pdf/templates/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Maps template ids to their components. Only imported from the lazy
+ * generateCvPdf chunk - every component here pulls in @react-pdf/renderer.
+ * UI code that needs names/descriptions imports ../templateMeta instead.
+ */
+import type { ComponentType } from 'react'
+import type { StructuredCv } from '../cvPdfTypes'
+import { DEFAULT_TEMPLATE_ID, type CvPdfTemplateId } from '../templateMeta'
+import SidebarCvPdf from '../CvPdfDocument'
+import MinimalCvPdf from './minimal'
+import HeaderBandCvPdf from './headerBand'
+import TimelineCvPdf from './timeline'
+
+const COMPONENTS: Record<CvPdfTemplateId, ComponentType<{ cv: StructuredCv }>> = {
+  sidebar: SidebarCvPdf,
+  headerBand: HeaderBandCvPdf,
+  minimal: MinimalCvPdf,
+  timeline: TimelineCvPdf,
+}
+
+export function getTemplateComponent(id: string | null | undefined): ComponentType<{ cv: StructuredCv }> {
+  return COMPONENTS[(id as CvPdfTemplateId) ?? DEFAULT_TEMPLATE_ID] ?? COMPONENTS[DEFAULT_TEMPLATE_ID]
+}

--- a/frontend/src/pdf/templates/minimal.tsx
+++ b/frontend/src/pdf/templates/minimal.tsx
@@ -1,0 +1,153 @@
+/**
+ * "Minimal Executive" template: single column, Swiss whitespace, hairline
+ * rules, accent used only for dates and bullet dashes.
+ */
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
+import type { StructuredCv, StructuredCvEducation, StructuredCvExperience, StructuredCvProject } from '../cvPdfTypes'
+import { ACCENT_DEEP, BODY, INK, MUTED, configurePdfHyphenation, contactValues } from '../shared'
+
+const styles = StyleSheet.create({
+  page: { fontFamily: 'Inter', paddingTop: 56, paddingBottom: 48, paddingHorizontal: 64, backgroundColor: '#ffffff' },
+  name: { fontSize: 30, fontWeight: 700, letterSpacing: -0.6, color: INK, lineHeight: 1.05 },
+  headline: { fontSize: 10.5, fontWeight: 500, letterSpacing: 3.2, textTransform: 'uppercase', color: ACCENT_DEEP, marginTop: 7 },
+  contactRow: { flexDirection: 'row', flexWrap: 'wrap', marginTop: 12 },
+  contactItem: { fontSize: 8.6, color: MUTED },
+  contactSep: { fontSize: 8.6, color: MUTED, marginHorizontal: 6 },
+  nameRule: { height: 2, backgroundColor: INK, marginTop: 18 },
+  section: { marginTop: 22 },
+  sectionHeading: { fontSize: 8.5, fontWeight: 700, letterSpacing: 2.4, textTransform: 'uppercase', color: INK, marginBottom: 10 },
+  entry: { marginBottom: 13 },
+  entryRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'baseline' },
+  entryTitle: { fontSize: 11, fontWeight: 600, color: INK },
+  entryDates: { fontSize: 8.6, fontWeight: 600, color: ACCENT_DEEP },
+  entrySub: { fontSize: 9, color: MUTED, marginTop: 1.5 },
+  bullet: { flexDirection: 'row', marginTop: 3.5 },
+  bulletDash: { width: 12, fontSize: 9.2, color: ACCENT_DEEP },
+  bulletText: { flex: 1, fontSize: 9.2, lineHeight: 1.5, color: BODY },
+  paragraph: { fontSize: 9.4, lineHeight: 1.6, color: BODY },
+  skillLine: { fontSize: 9.2, lineHeight: 1.55, color: BODY, marginBottom: 3 },
+  skillCat: { fontWeight: 600, color: INK },
+  footer: { position: 'absolute', bottom: 14, left: 64, right: 64, textAlign: 'right', fontSize: 7.5, color: '#9b8ec4' },
+})
+
+function Bullet({ text }: { text: string }) {
+  return (
+    <View style={styles.bullet}>
+      <Text style={styles.bulletDash}>–</Text>
+      <Text style={styles.bulletText}>{text}</Text>
+    </View>
+  )
+}
+
+function Entry({ title, sub, dates, bullets }: { title: string; sub?: string; dates?: string; bullets: string[] }) {
+  return (
+    <View style={styles.entry}>
+      <View style={styles.entryRow}>
+        <Text style={styles.entryTitle}>{title}</Text>
+        {dates ? <Text style={styles.entryDates}>{dates}</Text> : null}
+      </View>
+      {sub ? <Text style={styles.entrySub}>{sub}</Text> : null}
+      {bullets.map((b, i) => (
+        <Bullet key={i} text={b} />
+      ))}
+    </View>
+  )
+}
+
+function experienceEntry(e: StructuredCvExperience) {
+  return <Entry title={e.title} sub={[e.company, e.location].filter(Boolean).join(', ')} dates={e.dates} bullets={e.bullets} />
+}
+function projectEntry(p: StructuredCvProject) {
+  return <Entry title={p.name} dates={p.dates} bullets={p.bullets} />
+}
+function educationEntry(e: StructuredCvEducation) {
+  return <Entry title={e.degree} sub={e.institution} dates={e.dates} bullets={e.details} />
+}
+
+function Section({ title, blocks }: { title: string; blocks: JSX.Element[] }) {
+  if (blocks.length === 0) return null
+  return (
+    <View style={styles.section}>
+      <View wrap={false}>
+        <Text style={styles.sectionHeading}>{title}</Text>
+        {blocks[0]}
+      </View>
+      {blocks.slice(1).map((block, i) => (
+        <View key={i} wrap={false}>{block}</View>
+      ))}
+    </View>
+  )
+}
+
+export default function MinimalCvPdf({ cv }: { cv: StructuredCv }) {
+  configurePdfHyphenation()
+  const contacts = contactValues(cv)
+  return (
+    <Document title={`${cv.name} - CV`} author={cv.name} creator="CareerLens">
+      <Page size="A4" style={styles.page}>
+        <Text style={styles.name}>{cv.name}</Text>
+        {cv.headline ? <Text style={styles.headline}>{cv.headline}</Text> : null}
+        <View style={styles.contactRow}>
+          {contacts.map((item, i) => (
+            <View key={i} style={{ flexDirection: 'row' }}>
+              {i > 0 && <Text style={styles.contactSep}>·</Text>}
+              <Text style={styles.contactItem}>{item}</Text>
+            </View>
+          ))}
+        </View>
+        <View style={styles.nameRule} />
+
+        {cv.summary ? (
+          <View style={styles.section} wrap={false}>
+            <Text style={styles.sectionHeading}>Profile</Text>
+            <Text style={styles.paragraph}>{cv.summary}</Text>
+          </View>
+        ) : null}
+
+        <Section title="Experience" blocks={cv.experience.map((e, i) => <View key={i}>{experienceEntry(e)}</View>)} />
+        <Section title="Projects" blocks={cv.projects.map((p, i) => <View key={i}>{projectEntry(p)}</View>)} />
+
+        {cv.skills.length > 0 && (
+          <View style={styles.section} wrap={false}>
+            <Text style={styles.sectionHeading}>Skills</Text>
+            {cv.skills.map((g, i) => (
+              <Text key={i} style={styles.skillLine}>
+                {g.category ? <Text style={styles.skillCat}>{g.category}:  </Text> : null}
+                {g.items.join('  ·  ')}
+              </Text>
+            ))}
+          </View>
+        )}
+
+        <Section title="Education" blocks={cv.education.map((e, i) => <View key={i}>{educationEntry(e)}</View>)} />
+
+        {(cv.certifications.length > 0 || cv.languages.length > 0) && (
+          <View style={styles.section} wrap={false}>
+            <Text style={styles.sectionHeading}>Certifications & Languages</Text>
+            {cv.certifications.map((c, i) => (
+              <Bullet key={i} text={c} />
+            ))}
+            {cv.languages.length > 0 && (
+              <Text style={[styles.skillLine, { marginTop: 4 }]}>{cv.languages.join('  ·  ')}</Text>
+            )}
+          </View>
+        )}
+
+        {cv.extras.map((x, i) => (
+          <View key={i} style={styles.section} wrap={false}>
+            <Text style={styles.sectionHeading}>{x.label}</Text>
+            {x.items.map((item, j) => (
+              <Bullet key={j} text={item} />
+            ))}
+          </View>
+        ))}
+
+        <Text
+          style={styles.footer}
+          fixed
+          render={({ pageNumber, totalPages }) => (totalPages > 1 ? `${cv.name}  ·  ${pageNumber} / ${totalPages}` : '')}
+        />
+      </Page>
+    </Document>
+  )
+}

--- a/frontend/src/pdf/templates/timeline.tsx
+++ b/frontend/src/pdf/templates/timeline.tsx
@@ -1,0 +1,210 @@
+/**
+ * "Timeline" template: single column, experience entries hang on a vertical
+ * accent timeline, two-tone accent bar in the header, chip skills.
+ */
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
+import type { StructuredCv, StructuredCvExperience } from '../cvPdfTypes'
+import { ACCENT, ACCENT_DEEP, ACCENT_LIGHT, BODY, INK, MUTED, configurePdfHyphenation, contactValues, isSentenceLike } from '../shared'
+
+const styles = StyleSheet.create({
+  page: { fontFamily: 'Inter', paddingTop: 48, paddingBottom: 44, paddingHorizontal: 56, backgroundColor: '#ffffff' },
+  headerRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' },
+  name: { fontSize: 26, fontWeight: 700, letterSpacing: -0.5, color: INK, lineHeight: 1.08 },
+  headline: { fontSize: 10, fontWeight: 600, letterSpacing: 2.4, textTransform: 'uppercase', color: ACCENT_DEEP, marginTop: 5 },
+  contactCol: { alignItems: 'flex-end' },
+  contactItem: { fontSize: 8.2, color: MUTED, marginBottom: 2.5 },
+  accentBar: { flexDirection: 'row', marginTop: 16, marginBottom: 4 },
+  accentA: { width: 64, height: 4, backgroundColor: ACCENT, borderTopLeftRadius: 2, borderBottomLeftRadius: 2 },
+  accentB: { width: 26, height: 4, backgroundColor: '#c084fc', borderTopRightRadius: 2, borderBottomRightRadius: 2 },
+  section: { marginTop: 18 },
+  headingRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 10 },
+  headingSquare: { width: 7, height: 7, backgroundColor: ACCENT, borderRadius: 2, marginRight: 7 },
+  sectionHeading: { fontSize: 9.5, fontWeight: 700, letterSpacing: 1.8, textTransform: 'uppercase', color: INK },
+  paragraph: { fontSize: 9.4, lineHeight: 1.55, color: BODY },
+  tlEntry: { flexDirection: 'row' },
+  tlRail: { width: 20, alignItems: 'center' },
+  tlDot: { width: 8, height: 8, borderRadius: 4, backgroundColor: ACCENT, borderWidth: 1.5, borderColor: '#ffffff', marginTop: 2.5 },
+  tlLine: { flex: 1, width: 2, backgroundColor: 'rgba(139, 124, 246, 0.30)', marginTop: 2 },
+  tlBody: { flex: 1, paddingLeft: 8, paddingBottom: 14 },
+  tlDates: { fontSize: 8.2, fontWeight: 700, letterSpacing: 0.6, color: ACCENT_DEEP, textTransform: 'uppercase' },
+  entryTitle: { fontSize: 10.6, fontWeight: 600, color: INK, marginTop: 2 },
+  entrySub: { fontSize: 8.8, fontWeight: 500, color: MUTED, marginTop: 1.5 },
+  bullet: { flexDirection: 'row', marginTop: 3.5 },
+  dot: { width: 3, height: 3, borderRadius: 1.5, backgroundColor: ACCENT, marginTop: 4.2, marginRight: 6 },
+  bulletText: { flex: 1, fontSize: 9.1, lineHeight: 1.45, color: BODY },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap' },
+  chip: { backgroundColor: ACCENT_LIGHT, borderRadius: 9, paddingVertical: 3, paddingHorizontal: 8, marginRight: 5, marginBottom: 5 },
+  chipText: { fontSize: 8.2, fontWeight: 500, color: ACCENT_DEEP },
+  chipCat: { fontSize: 8, fontWeight: 600, color: MUTED, marginBottom: 4, marginTop: 2 },
+  twoCol: { flexDirection: 'row', marginTop: 4 },
+  colHalf: { flex: 1, paddingRight: 16 },
+  smallText: { fontSize: 9, lineHeight: 1.45, color: BODY, marginBottom: 3 },
+  smallTitle: { fontSize: 9.6, fontWeight: 600, color: INK },
+  footer: { position: 'absolute', bottom: 12, left: 56, right: 56, textAlign: 'right', fontSize: 7.5, color: '#9b8ec4' },
+})
+
+function Heading({ title }: { title: string }) {
+  return (
+    <View style={styles.headingRow}>
+      <View style={styles.headingSquare} />
+      <Text style={styles.sectionHeading}>{title}</Text>
+    </View>
+  )
+}
+
+function Bullet({ text }: { text: string }) {
+  return (
+    <View style={styles.bullet}>
+      <View style={styles.dot} />
+      <Text style={styles.bulletText}>{text}</Text>
+    </View>
+  )
+}
+
+function TimelineEntry({ entry, last }: { entry: StructuredCvExperience; last: boolean }) {
+  const sub = [entry.company, entry.location].filter(Boolean).join('  ·  ')
+  return (
+    <View style={styles.tlEntry}>
+      <View style={styles.tlRail}>
+        <View style={styles.tlDot} />
+        {!last && <View style={styles.tlLine} />}
+      </View>
+      <View style={styles.tlBody}>
+        {entry.dates ? <Text style={styles.tlDates}>{entry.dates}</Text> : null}
+        <Text style={styles.entryTitle}>{entry.title}</Text>
+        {sub ? <Text style={styles.entrySub}>{sub}</Text> : null}
+        {entry.bullets.map((b, j) => (
+          <Bullet key={j} text={b} />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+export default function TimelineCvPdf({ cv }: { cv: StructuredCv }) {
+  configurePdfHyphenation()
+  return (
+    <Document title={`${cv.name} - CV`} author={cv.name} creator="CareerLens">
+      <Page size="A4" style={styles.page}>
+        <View style={styles.headerRow}>
+          <View style={{ flex: 1, paddingRight: 12 }}>
+            <Text style={styles.name}>{cv.name}</Text>
+            {cv.headline ? <Text style={styles.headline}>{cv.headline}</Text> : null}
+            <View style={styles.accentBar}>
+              <View style={styles.accentA} />
+              <View style={styles.accentB} />
+            </View>
+          </View>
+          <View style={styles.contactCol}>
+            {contactValues(cv).map((item, i) => (
+              <Text key={i} style={styles.contactItem}>{item}</Text>
+            ))}
+          </View>
+        </View>
+
+        {cv.summary ? (
+          <View style={styles.section} wrap={false}>
+            <Heading title="Profile" />
+            <Text style={styles.paragraph}>{cv.summary}</Text>
+          </View>
+        ) : null}
+
+        {cv.experience.length > 0 && (
+          <View style={styles.section}>
+            <View wrap={false}>
+              <Heading title="Experience" />
+              <TimelineEntry entry={cv.experience[0]} last={cv.experience.length === 1} />
+            </View>
+            {cv.experience.slice(1).map((e, i) => (
+              <View key={i} wrap={false}>
+                <TimelineEntry entry={e} last={i === cv.experience.length - 2} />
+              </View>
+            ))}
+          </View>
+        )}
+
+        {cv.skills.length > 0 && (
+          <View style={styles.section} wrap={false}>
+            <Heading title="Skills" />
+            {cv.skills.map((g, i) => (
+              <View key={i}>
+                {g.category ? <Text style={styles.chipCat}>{g.category}</Text> : null}
+                <View style={styles.chipRow}>
+                  {g.items.filter((s) => !isSentenceLike(s)).map((s, j) => (
+                    <View key={j} style={styles.chip}>
+                      <Text style={styles.chipText}>{s}</Text>
+                    </View>
+                  ))}
+                </View>
+                {g.items.filter(isSentenceLike).map((s, j) => (
+                  <Bullet key={`s${j}`} text={s} />
+                ))}
+              </View>
+            ))}
+          </View>
+        )}
+
+        {cv.projects.length > 0 && (
+          <View style={styles.section} wrap={false}>
+            <Heading title="Projects" />
+            {cv.projects.map((p, i) => (
+              <View key={i} style={{ marginBottom: 8 }}>
+                <Text style={styles.smallTitle}>{p.name}{p.dates ? `  ·  ${p.dates}` : ''}</Text>
+                {p.bullets.map((x, j) => (
+                  <Bullet key={j} text={x} />
+                ))}
+              </View>
+            ))}
+          </View>
+        )}
+
+        <View style={styles.twoCol} wrap={false}>
+          {cv.education.length > 0 && (
+            <View style={styles.colHalf}>
+              <View style={styles.section}>
+                <Heading title="Education" />
+                {cv.education.map((e, i) => (
+                  <View key={i} style={{ marginBottom: 6 }}>
+                    <Text style={styles.smallTitle}>{e.degree}</Text>
+                    <Text style={styles.smallText}>{[e.institution, e.dates].filter(Boolean).join(' · ')}</Text>
+                    {e.details.map((d, j) => (
+                      <Bullet key={j} text={d} />
+                    ))}
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+          {(cv.certifications.length > 0 || cv.languages.length > 0) && (
+            <View style={styles.colHalf}>
+              <View style={styles.section}>
+                <Heading title="Certifications & Languages" />
+                {cv.certifications.map((x, i) => (
+                  <Bullet key={i} text={x} />
+                ))}
+                {cv.languages.length > 0 && (
+                  <Text style={[styles.smallText, { marginTop: 5 }]}>{cv.languages.join('  ·  ')}</Text>
+                )}
+              </View>
+            </View>
+          )}
+        </View>
+
+        {cv.extras.map((x, i) => (
+          <View key={i} style={styles.section} wrap={false}>
+            <Heading title={x.label} />
+            {x.items.map((item, j) => (
+              <Bullet key={j} text={item} />
+            ))}
+          </View>
+        ))}
+
+        <Text
+          style={styles.footer}
+          fixed
+          render={({ pageNumber, totalPages }) => (totalPages > 1 ? `${cv.name}  ·  ${pageNumber} / ${totalPages}` : '')}
+        />
+      </Page>
+    </Document>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,6 +2,7 @@
  * API base: relative `/api` in dev (Vite proxies to backend) unless VITE_API_BASE_URL is set.
  */
 import { clearUserFlowSession } from '../utils/userFlowSession'
+import type { StructuredCv } from '../pdf/cvPdfTypes'
 
 function apiBase(): string {
   const raw = import.meta.env.VITE_API_BASE_URL?.trim()
@@ -570,6 +571,24 @@ export async function mergeCv(
   }
   const data = await res.json() as { mergedCvText: string }
   return data.mergedCvText
+}
+
+export async function structureCvForPdf(
+  cvText: string,
+  jobTitle?: string
+): Promise<StructuredCv> {
+  const res = await apiFetch(`${base()}/cv-improve/structure`, {
+    method: 'POST',
+    headers: { ...jsonHeaders, ...authHeaders() },
+    body: JSON.stringify({ cvText, jobTitle }),
+  }, LLM_TIMEOUT_MS)
+  await handleUnauthorized(res)
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || `PDF preparation failed (${res.status})`)
+  }
+  const data = await res.json() as { structured: StructuredCv }
+  return data.structured
 }
 
 export async function saveImprovementSession(payload: {


### PR DESCRIPTION
## What

Adds a designed-PDF export to the improve-flow result screen, alongside the existing plain-text export. The Export button now opens a menu: **Styled PDF** (with a picker of 4 designs) or **Plain text (.txt)**.

## How it works

- **Structuring**: new `cvStructure` agent behind `POST /api/cv-improve/structure` converts the improved CV text into a typed `StructuredCv` JSON. The prompt is organize-only - content is copied verbatim, nothing invented or dropped - and the output passes defensive normalization before rendering.
- **Rendering**: four @react-pdf/renderer templates (classic sidebar, header band, minimal, timeline) share a palette/helpers module. Skill items that read like sentences (the improve flow appends those) render as list rows instead of chips so the improvements stay visible.
- **UI**: template picker inside the Export menu; the last choice is persisted in localStorage and highlighted next time.
- **Performance**: the renderer + Inter fonts live in a lazy chunk (~486KB gzip) loaded only on first PDF export; the main bundle grows by ~1.5KB. The structured JSON is cached per merged text, so repeat exports skip the LLM round-trip.

## Testing

- Backend and frontend type-check and build clean.
- E2E via the running app: login -> improve flow -> Export -> each template downloads a correct PDF; live /structure call returns 200 with zero console errors; cache confirmed (repeat export makes no extra LLM call).
- Rendered output reviewed page-by-page for one- and two-page CVs: pagination, fixed sidebar band, footer, no orphaned section headings, long-URL wrapping.
- Dev scripts included to preview all templates (`frontend/scripts/render-design-options.tsx`) and to render a live /structure response through a template (`render-structured-cv.tsx`).