### PR TITLE
fix(frontend): mobile display fixes for the home screen

### DIFF
--- a/frontend/src/components/ui/ShaderBackground.tsx
+++ b/frontend/src/components/ui/ShaderBackground.tsx
@@ -160,8 +160,11 @@ const ShaderBackground = () => {
     const uTime         = gl.getUniformLocation(program, 'iTime')
 
     const resize = () => {
-      canvas.width  = canvas.offsetWidth
-      canvas.height = canvas.offsetHeight
+      // render at device resolution (capped for perf) - a CSS-pixel canvas is
+      // upscaled ~3x on phones, turning the plasma lines into blurry streaks
+      const dpr = Math.min(window.devicePixelRatio || 1, 2)
+      canvas.width  = Math.round(canvas.offsetWidth * dpr)
+      canvas.height = Math.round(canvas.offsetHeight * dpr)
       gl.viewport(0, 0, canvas.width, canvas.height)
     }
     window.addEventListener('resize', resize)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,10 +49,18 @@
   box-sizing: border-box;
 }
 
+/* Invisible absolutely-positioned helpers (tooltips) must never widen the
+   page into a horizontal scroll on narrow screens. */
+html {
+  overflow-x: clip;
+}
+
 body {
   min-width: 320px;
   min-height: 100vh;
+  min-height: 100dvh;
   background-color: var(--color-bg);
+  overflow-x: clip;
 }
 
 #root {
@@ -112,4 +120,10 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   [data-tooltip]::after { transition: none; }
+}
+
+/* No hover on touch devices - the tooltip can never open, but its laid-out
+   box (up to 70vw wide, anchored left) still stretches the page sideways. */
+@media (hover: none) {
+  [data-tooltip]::after { display: none; }
 }

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -1,7 +1,11 @@
 /* ─── Page ─────────────────────────────────────────────────────────── */
 .home-page {
   min-height: 100vh;
-  background: var(--color-bg);
+  min-height: 100dvh;
+  /* Dark, like the hero and the two sections after it: on mobile DPRs the
+     section heights round to fractional pixels and a light page background
+     bleeds through the seams as thin white lines. */
+  background: #0a0828;
   scroll-behavior: smooth;
 }
 
@@ -9,6 +13,9 @@
 .hero {
   position: relative;
   height: 100vh;
+  /* svh = viewport with the mobile address bar visible, so the scroll
+     indicator is never hidden behind it and no gap opens when it collapses */
+  height: 100svh;
   min-height: 600px;
   display: flex;
   align-items: center;
@@ -106,6 +113,8 @@
 /* ─── Hero CTA ─────────────────────────────────────────────────────── */
 .hero-actions {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 1rem;
   margin-top: 0.5rem;
 }
@@ -645,6 +654,7 @@ a.btn-hero-logout {
 /* ─── Responsive ───────────────────────────────────────────────────── */
 @media (max-width: 600px) {
   .hero-tagline { font-size: 1rem; }
+  .hero-subheadline br { display: none; }
   .hero-stats   { gap: 1rem; padding: 0.75rem 1.25rem; }
   .upload-section { padding: 3rem 1rem 4rem; }
   .hiw-steps { flex-direction: column; align-items: center; }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -54,8 +54,8 @@ const HomePage = () => {
 
           <h1 className="hero-headline">Does your CV match today's job market?</h1>
           <p className="hero-subheadline">
-            CareerLens uses a data-science model to extract the key skills from any job posting<br />
-            and score your CV against them, so you know exactly what to improve.
+            CareerLens uses a data-science model to extract the key skills from any job posting{' '}
+            <br />and score your CV against them, so you know exactly what to improve.
           </p>
 
           <div className="hero-actions">

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 8080,
+    host: true, // listen on the LAN so the app opens from a phone on the same Wi-Fi
     open: true,
     proxy: {
       '/api': {


### PR DESCRIPTION
## What

Fixes the broken mobile display of the home screen (white stripes at the edges, horizontal scroll, blurry hero background) and makes the app reachable from a phone on the local network.

## Root causes found

- Invisible `[data-tooltip]::after` pseudo-elements (up to 70vw wide, opacity 0 but still laid out) stretched the page to ~468px on a 390px viewport - the light page background showed as white stripes and the page scrolled sideways.
- The hero action buttons row did not wrap on narrow screens.
- The light `.home-page` background bled through subpixel seams between the dark sections on mobile DPRs.
- `height: 100vh` on the hero fights the mobile address bar.
- The shader canvas rendered at CSS-pixel resolution, upscaled ~3x on phones.

## Changes

- `overflow-x: clip` on `html`/`body` (on `body` alone the viewport still scrolls); tooltips hidden under `@media (hover: none)`.
- `.hero-actions` wraps and centers; subheadline `<br>` hidden on small screens with an explicit space.
- `.home-page` background switched to the dark section color.
- Hero height `100svh` with `100vh` fallback.
- Shader canvas renders at device resolution (devicePixelRatio, capped at 2).
- `host: true` in `vite.config.ts` so the dev server listens on the LAN.

## Verification

Checked in a 390x844 viewport with Playwright: scrollWidth equals the viewport width, horizontal scroll attempts stay at 0, buttons wrap into two rows, and the desktop layout (1366px) is unchanged.